### PR TITLE
Account Selector display both chain accounts and switch source/target based on the account selected.

### DIFF
--- a/src/components/Accounts.tsx
+++ b/src/components/Accounts.tsx
@@ -90,7 +90,7 @@ const Accounts = ({ className }: Props) => {
           }}
           renderValue={(): React.ReactNode => <AccountSelected />}
         >
-          {accounts.length && chains.map((chain) => renderAccounts(chain))}
+          {chains.map((chain) => renderAccounts(chain))}
         </Select>
       </FormControl>
       {derivedAccount && (

--- a/src/components/Accounts.tsx
+++ b/src/components/Accounts.tsx
@@ -13,6 +13,23 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
+// Copyright 2021 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges UI.
+//
+// Parity Bridges UI is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Parity Bridges UI is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import Container from '@material-ui/core/Container';
 import FormControl from '@material-ui/core/FormControl';

--- a/src/components/Accounts.tsx
+++ b/src/components/Accounts.tsx
@@ -19,12 +19,14 @@ import FormControl from '@material-ui/core/FormControl';
 import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
 import Select from '@material-ui/core/Select';
-import type { KeyringPair } from '@polkadot/keyring/types';
-import React from 'react';
+import { encodeAddress } from '@polkadot/util-crypto';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { useSourceTarget } from '../contexts/SourceTargetContextProvider';
 import useAccounts from '../hooks/useAccounts';
+import formatAccounts from '../util/formatAccounts';
+import getChainSS58 from '../util/getSS58';
 import Account from './Account';
 import SubHeader from './SubHeader';
 
@@ -32,35 +34,36 @@ interface Props {
   className?: string;
 }
 
-const formatOptions = (accounts: Array<KeyringPair>) =>
-  accounts.map(({ meta, address }) => ({
-    icon: 'user',
-    key: address,
-    text: (meta.name as string).toLocaleUpperCase(),
-    value: address
-  }));
-
 const Accounts = ({ className }: Props) => {
+  const [chains, setChains] = useState<Array<string>>([]);
   const { account, accounts, derivedAccount, setCurrentAccount } = useAccounts();
   const {
-    sourceChainDetails: { sourceChain }
+    sourceChainDetails: { sourceChain },
+    targetChainDetails: { targetChain }
   } = useSourceTarget();
 
-  const value = account?.address || '';
+  useEffect(() => {
+    if (!chains.length) {
+      setChains([sourceChain, targetChain]);
+    }
+  }, [chains.length, sourceChain, targetChain]);
 
-  const onChange = (event: React.ChangeEvent<{ value: unknown }>) => {
-    setCurrentAccount(event.target.value as string);
+  const value = account ? encodeAddress(account.address, getChainSS58(sourceChain)) : '';
+
+  const onChange = (value: string, chain: string) => {
+    setCurrentAccount(value, chain);
   };
 
-  if (!accounts.length) {
-    return null;
-  }
-
-  const formatedAccounts = formatOptions(accounts);
-
-  const renderAccounts = ({ formatedAccounts, chain }: any) => {
+  const renderAccounts = (chain: string) => {
+    const formatedAccounts = formatAccounts(accounts, chain);
     const items = formatedAccounts.map(({ text, value, key }: any) => (
-      <MenuItem key={key} value={value}>
+      <MenuItem
+        key={key}
+        value={value}
+        onClick={() => {
+          onChange(value, chain);
+        }}
+      >
         <Account text={text} value={value} showDerivedBalance />
       </MenuItem>
     ));
@@ -81,17 +84,20 @@ const Accounts = ({ className }: Props) => {
       <FormControl variant="outlined" className="formControl">
         <Select
           value={value}
-          onChange={onChange}
           name="name"
           inputProps={{
             id: 'name-native-error'
           }}
           renderValue={(): React.ReactNode => <Input />}
         >
-          {renderAccounts({ chain: sourceChain, formatedAccounts })}
+          {accounts.length && chains.map((chain) => renderAccounts(chain))}
         </Select>
       </FormControl>
-      {derivedAccount && <Account text="Derived Account" value={derivedAccount} />}
+      {derivedAccount && (
+        <div className="formControl">
+          <Account text="Derived Account" value={derivedAccount} />
+        </div>
+      )}
     </Container>
   );
 };
@@ -99,7 +105,7 @@ const Accounts = ({ className }: Props) => {
 export default styled(Accounts)`
   margin: 40px 0;
   .formControl {
-    min-width: 700px;
+    width: 700px;
   }
   .chainSelect {
     font-size: 18px;

--- a/src/components/Accounts.tsx
+++ b/src/components/Accounts.tsx
@@ -13,23 +13,6 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
-// Copyright 2021 Parity Technologies (UK) Ltd.
-// This file is part of Parity Bridges UI.
-//
-// Parity Bridges UI is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// Parity Bridges UI is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
-
-/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import Container from '@material-ui/core/Container';
 import FormControl from '@material-ui/core/FormControl';

--- a/src/components/Accounts.tsx
+++ b/src/components/Accounts.tsx
@@ -70,7 +70,7 @@ const Accounts = ({ className }: Props) => {
     return [<SubHeader key={chain} chain={chain} />, items];
   };
 
-  const Input = () => {
+  const AccountSelected = () => {
     if (account) {
       const text = (account.meta.name as string).toLocaleUpperCase();
       return <Account text={text} value={value} />;
@@ -88,7 +88,7 @@ const Accounts = ({ className }: Props) => {
           inputProps={{
             id: 'name-native-error'
           }}
-          renderValue={(): React.ReactNode => <Input />}
+          renderValue={(): React.ReactNode => <AccountSelected />}
         >
           {accounts.length && chains.map((chain) => renderAccounts(chain))}
         </Select>

--- a/src/contexts/KeyringContextProvider.tsx
+++ b/src/contexts/KeyringContextProvider.tsx
@@ -20,11 +20,9 @@ import keyring from '@polkadot/ui-keyring';
 import React, { useCallback, useContext, useEffect, useState } from 'react';
 
 import { MessageActionsCreators } from '../actions/messageActions';
-import { getChainConfigs } from '../configs/substrateProviders';
 import { useUpdateMessageContext } from '../contexts/MessageContext';
 import { KeyringContextType, KeyringStatuses } from '../types/keyringTypes';
 import logger from '../util/logger';
-import { useSourceTarget } from './SourceTargetContextProvider';
 
 interface KeyringContextProviderProps {
   children: React.ReactElement;
@@ -38,11 +36,6 @@ export function useKeyringContext() {
 
 export function KeyringContextProvider(props: KeyringContextProviderProps): React.ReactElement {
   const { children = null } = props;
-  const {
-    sourceChainDetails: { sourceChain }
-  } = useSourceTarget();
-  const chainsConfigs = getChainConfigs();
-  const sourceChainSS58Format = chainsConfigs[sourceChain].SS58Format;
   const [keyringStatus, setKeyringStatus] = useState(KeyringStatuses.INIT);
   const { dispatchMessage } = useUpdateMessageContext();
   const [keyringPairs, setKeyringPairs] = useState<Array<KeyringPair>>([]);
@@ -61,7 +54,7 @@ export function KeyringContextProvider(props: KeyringContextProviderProps): Reac
           meta: { ...meta, name: `${meta.name} (${meta.source})` }
         }));
 
-        keyring.loadAll({ isDevelopment, ss58Format: sourceChainSS58Format }, allAccounts);
+        keyring.loadAll({ isDevelopment }, allAccounts);
         setKeyringStatus(KeyringStatuses.READY);
       } catch (e) {
         dispatchMessage(MessageActionsCreators.triggerErrorMessage({ message: e }));
@@ -73,7 +66,7 @@ export function KeyringContextProvider(props: KeyringContextProviderProps): Reac
     if (keyringStatus === KeyringStatuses.LOADING || keyringStatus === KeyringStatuses.READY) return;
 
     asyncLoadAccounts();
-  }, [dispatchMessage, isDevelopment, keyringStatus, sourceChainSS58Format]);
+  }, [dispatchMessage, isDevelopment, keyringStatus]);
 
   useEffect(() => {
     if (keyringStatus === KeyringStatuses.INIT) {

--- a/src/reducers/sourceTargetReducer.ts
+++ b/src/reducers/sourceTargetReducer.ts
@@ -20,18 +20,21 @@ import { ChainDetails, SourceTargetAction, SourceTargetState } from '../types/so
 export default function sourceTargetReducer(state: SourceTargetState, action: SourceTargetAction): SourceTargetState {
   switch (action.type) {
     case SourceTargetActionsTypes.SWAP_CHAINS: {
-      return {
-        [ChainDetails.SOURCE]: {
-          sourceApiConnection: state[ChainDetails.TARGET].targetApiConnection,
-          sourceChain: state[ChainDetails.TARGET].targetChain,
-          sourcePolkadotjsUrl: state[ChainDetails.TARGET].targetPolkadotjsUrl
-        },
-        [ChainDetails.TARGET]: {
-          targetApiConnection: state[ChainDetails.SOURCE].sourceApiConnection,
-          targetChain: state[ChainDetails.SOURCE].sourceChain,
-          targetPolkadotjsUrl: state[ChainDetails.SOURCE].sourcePolkadotjsUrl
-        }
-      };
+      if (action.payload!.chain !== state[ChainDetails.SOURCE].sourceChain) {
+        return {
+          [ChainDetails.SOURCE]: {
+            sourceApiConnection: state[ChainDetails.TARGET].targetApiConnection,
+            sourceChain: state[ChainDetails.TARGET].targetChain,
+            sourcePolkadotjsUrl: state[ChainDetails.TARGET].targetPolkadotjsUrl
+          },
+          [ChainDetails.TARGET]: {
+            targetApiConnection: state[ChainDetails.SOURCE].sourceApiConnection,
+            targetChain: state[ChainDetails.SOURCE].sourceChain,
+            targetPolkadotjsUrl: state[ChainDetails.SOURCE].sourcePolkadotjsUrl
+          }
+        };
+      }
+      return state;
     }
     default: {
       throw new Error(`Unhandled type: ${action.type}`);

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -17,10 +17,9 @@
 import Container from '@material-ui/core/Container';
 import Grid from '@material-ui/core/Grid';
 import React from 'react';
-import { Button, Icon } from 'semantic-ui-react';
+import { Icon } from 'semantic-ui-react';
 import styled from 'styled-components';
 
-import { SourceTargetActionsCreators } from '../actions/sourceTargetActions';
 import Accounts from '../components/Accounts';
 import CustomCall from '../components/CustomCall';
 import DashboardCard from '../components/DashboardCard';
@@ -28,8 +27,7 @@ import Remark from '../components/Remark';
 import SnackBar from '../components/SnackBar';
 import Transactions from '../components/Transactions';
 import Transfer from '../components/Transfer';
-import { useSourceTarget, useUpdateSourceTarget } from '../contexts/SourceTargetContextProvider';
-import useLoadingApi from '../hooks/useLoadingApi';
+import { useSourceTarget } from '../contexts/SourceTargetContextProvider';
 import { ChainDetails } from '../types/sourceTargetTypes';
 
 interface Props {
@@ -37,11 +35,7 @@ interface Props {
 }
 
 export function Main({ className }: Props) {
-  const areApiLoading = useLoadingApi();
   const { sourceChainDetails, targetChainDetails } = useSourceTarget();
-
-  const { dispatchChangeSourceTarget } = useUpdateSourceTarget();
-  const onChangeSourceTarget = () => dispatchChangeSourceTarget(SourceTargetActionsCreators.switchChains());
 
   return (
     <>
@@ -55,9 +49,7 @@ export function Main({ className }: Props) {
           </Grid>
           <Grid item md={1}>
             <div className="switchButton">
-              <Button disabled={!areApiLoading} onClick={onChangeSourceTarget}>
-                <Icon fitted name="exchange" />
-              </Button>
+              <Icon fitted name="exchange" />
             </div>
           </Grid>
           <Grid item md={5}>

--- a/src/util/formatAccounts.ts
+++ b/src/util/formatAccounts.ts
@@ -14,17 +14,20 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
 
-enum SourceTargetActionsTypes {
-  SWAP_CHAINS = 'SWAP_CHAINS'
+import type { KeyringPair } from '@polkadot/keyring/types';
+import { encodeAddress } from '@polkadot/util-crypto';
+
+import getChainSS58 from '../util/getSS58';
+
+export default function formatAccounts(accounts: Array<KeyringPair>, chain: string) {
+  return accounts.map(({ meta, address }) => {
+    const ss58Format = getChainSS58(chain);
+    const formatedAddress = encodeAddress(address, ss58Format);
+    return {
+      icon: 'user',
+      key: formatedAddress,
+      text: (meta.name as string).toLocaleUpperCase(),
+      value: formatedAddress
+    };
+  });
 }
-
-const switchChains = (chain: string) => ({
-  payload: { chain },
-  type: SourceTargetActionsTypes.SWAP_CHAINS
-});
-
-const SourceTargetActionsCreators = {
-  switchChains
-};
-
-export { SourceTargetActionsTypes, SourceTargetActionsCreators };

--- a/src/util/formatAccounts.ts
+++ b/src/util/formatAccounts.ts
@@ -20,6 +20,7 @@ import { encodeAddress } from '@polkadot/util-crypto';
 import getChainSS58 from '../util/getSS58';
 
 export default function formatAccounts(accounts: Array<KeyringPair>, chain: string) {
+  // TO-DO: This function lacks the  capabillity to filter accounts that exist only on specific chains.
   return accounts.map(({ meta, address }) => {
     const ss58Format = getChainSS58(chain);
     const formatedAddress = encodeAddress(address, ss58Format);

--- a/src/util/getSS58.ts
+++ b/src/util/getSS58.ts
@@ -14,17 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
 
-enum SourceTargetActionsTypes {
-  SWAP_CHAINS = 'SWAP_CHAINS'
+import { getChainConfigs } from '../configs/substrateProviders';
+const chainsConfigs = getChainConfigs();
+
+export default function getChainSS58(chain: string) {
+  return chainsConfigs[chain].SS58Format;
 }
-
-const switchChains = (chain: string) => ({
-  payload: { chain },
-  type: SourceTargetActionsTypes.SWAP_CHAINS
-});
-
-const SourceTargetActionsCreators = {
-  switchChains
-};
-
-export { SourceTargetActionsTypes, SourceTargetActionsCreators };


### PR DESCRIPTION
This PR includes two functionalities:

- Display both chains in the account selector with their respective derived accounts.
- Switch source target according to what it is selected.

As i pointed out in in the comment of the file `src/util/formatAccounts.ts`  this implementation does not support specific accounts per chain. That will be implemented on task  #74 