### PR TITLE
Adding generic account component

### DIFF
--- a/src/components/AccountDisplay.tsx
+++ b/src/components/AccountDisplay.tsx
@@ -51,7 +51,8 @@ const useStyles = makeStyles(() => ({
     alignItems: 'center'
   },
   address: {
-    marginLeft: '10px'
+    marginLeft: '10px',
+    width: '100%'
   },
   balances: {
     marginLeft: 'auto'
@@ -65,7 +66,7 @@ const AccountDisplay = ({ accountName, address = '', balance, isDerived = false,
       return '';
     }
     if (isDerived) {
-      return `derived(${accountName || shorterItem(address)})`;
+      return `Derived (${accountName || shorterItem(address)})`;
     }
     if (accountName) {
       return `${accountName} (${shorterItem(address)})`;

--- a/src/components/GenericAccount.tsx
+++ b/src/components/GenericAccount.tsx
@@ -1,0 +1,107 @@
+// Copyright 2021 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges UI.
+//
+// Parity Bridges UI is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Parity Bridges UI is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
+
+import Container from '@material-ui/core/Container';
+import { encodeAddress } from '@polkadot/util-crypto';
+import React, { useState } from 'react';
+import { useUpdateTransactionContext } from '../contexts/TransactionContext';
+import { TransactionActionCreators } from '../actions/transactionActions';
+import { getChainConfigs } from '../configs/substrateProviders';
+import { makeStyles } from '@material-ui/core/styles';
+import { useSourceTarget } from '../contexts/SourceTargetContextProvider';
+import useBalance from '../hooks/useBalance';
+import getDeriveAccount from '../util/getDeriveAccount';
+import AccountDisplay from './AccountDisplay';
+
+interface Props {
+  value: string;
+  isDerived?: boolean;
+}
+
+const useStyles = makeStyles(() => ({
+  container: {
+    padding: '0',
+    float: 'left'
+  },
+  native: {
+    border: '1px solid',
+    borderTop: 'none',
+    padding: '5px 0'
+  },
+  companion: {
+    border: '1px solid',
+    borderTop: 'none',
+    borderRadius: '0 0 5px 5px',
+    padding: '5px 0'
+  }
+}));
+
+const NATIVE = 'NATIVE';
+const DERIVED = 'DERIVED';
+
+const GenericAccount = ({ value }: Props) => {
+  const [selected, setSelected] = useState('');
+  const classes = useStyles();
+  const {
+    targetChainDetails: {
+      targetApiConnection: { api: targetApi },
+      targetChain
+    },
+    sourceChainDetails: { sourceChain }
+  } = useSourceTarget();
+
+  const { dispatchTransaction } = useUpdateTransactionContext();
+  const chainsConfigs = getChainConfigs();
+  const { bridgeId } = chainsConfigs[sourceChain];
+  const { SS58Format: targetSS58Format } = chainsConfigs[targetChain];
+
+  const nativeAddress = encodeAddress(value, targetSS58Format);
+  const nativeState = useBalance(targetApi, nativeAddress, true);
+
+  const derivedAddress = getDeriveAccount({
+    SS58Format: targetSS58Format,
+    address: value,
+    bridgeId
+  });
+  const derivedState = useBalance(targetApi, derivedAddress, true);
+
+  const setNativeAsTarget = () => {
+    setSelected(NATIVE);
+    dispatchTransaction(TransactionActionCreators.setReceiverAddress(nativeAddress));
+  };
+
+  const setCompanionAsTarget = () => {
+    setSelected(DERIVED);
+    dispatchTransaction(TransactionActionCreators.setReceiverAddress(derivedAddress));
+  };
+
+  return (
+    <Container className={classes.container}>
+      {(!selected || selected === NATIVE) && (
+        <div className={classes.native} onClick={setNativeAsTarget}>
+          <AccountDisplay accountName="Native" address={nativeAddress} balance={nativeState.formattedBalance} />
+        </div>
+      )}
+      {(!selected || selected === DERIVED) && (
+        <div className={classes.companion} onClick={setCompanionAsTarget}>
+          <AccountDisplay address={derivedAddress} isDerived balance={derivedState.formattedBalance} />
+        </div>
+      )}
+    </Container>
+  );
+};
+
+export default GenericAccount;

--- a/src/components/Receiver.tsx
+++ b/src/components/Receiver.tsx
@@ -42,7 +42,7 @@ const Receiver = () => {
       <div className={classes.input}>
         <ReceiverInput setError={setError} />
       </div>
-      <ReceiverDerivedAccount setError={setError} />
+      <ReceiverDerivedAccount />
       <div>
         <p>{error}</p>
       </div>

--- a/src/components/ReceiverDerivedAccount.tsx
+++ b/src/components/ReceiverDerivedAccount.tsx
@@ -20,10 +20,7 @@ import { useSourceTarget } from '../contexts/SourceTargetContextProvider';
 import { useTransactionContext } from '../contexts/TransactionContext';
 import Account from './Account';
 import AccountDisplay from './AccountDisplay';
-
-interface Props {
-  setError: (value: string) => void;
-}
+import GenericAccount from './GenericAccount';
 
 const useStyles = makeStyles(() => ({
   derived: {
@@ -36,7 +33,7 @@ const useStyles = makeStyles(() => ({
   }
 }));
 
-const ReceiverDerivedAccount = ({ setError }: Props) => {
+const ReceiverDerivedAccount = () => {
   const classes = useStyles();
   const { genericReceiverAccount, derivedReceiverAccount, receiverAddress } = useTransactionContext();
 
@@ -45,8 +42,7 @@ const ReceiverDerivedAccount = ({ setError }: Props) => {
   } = useSourceTarget();
 
   if (genericReceiverAccount) {
-    // TO-DO to replace this callback with proper <GenericAccount /> component.
-    setError('A generic account was provided. Please provide a source/target valid account');
+    return <GenericAccount value={genericReceiverAccount} />;
   }
 
   if (derivedReceiverAccount) {
@@ -56,6 +52,7 @@ const ReceiverDerivedAccount = ({ setError }: Props) => {
       </div>
     );
   }
+
   return (
     <div className={classes.derived}>
       <AccountDisplay isDerived />

--- a/src/components/ReceiverInput.tsx
+++ b/src/components/ReceiverInput.tsx
@@ -81,6 +81,7 @@ function ReceiverInput({ setError }: Props) {
   const reset = useCallback(() => {
     dispatchTransaction(TransactionActionCreators.setGenericAccount(null));
     dispatchTransaction(TransactionActionCreators.setDerivedAccount(null));
+    dispatchTransaction(TransactionActionCreators.setReceiverAddress(null));
     setShowBalance(false);
     setError('');
   }, [dispatchTransaction, setError]);
@@ -114,13 +115,18 @@ function ReceiverInput({ setError }: Props) {
 
     if (formatFound === targetChain) {
       setReceiver(formattedAccount);
+      setShowBalance(true);
+      return;
     }
+
     if (formatFound === sourceChain) {
       dispatchTransaction(TransactionActionCreators.setDerivedAccount(formattedAccount));
       setReceiver(receiver);
+      setShowBalance(true);
+      return;
     }
 
-    setShowBalance(true);
+    setError(`Unsupported address SS58 prefix: ${formatFound}`);
   };
 
   return (

--- a/src/hooks/useSendMessage.ts
+++ b/src/hooks/useSendMessage.ts
@@ -148,6 +148,7 @@ function useSendMessage({ isRunning, isValidCall, setIsRunning, input, type, wei
         return isRunning || !account;
         break;
       case TransactionTypes.TRANSFER:
+        console.log('asdf', receiverAddress, account);
         return isRunning || !receiverAddress || !account;
         break;
       case TransactionTypes.CUSTOM:

--- a/src/util/getReceiverAddress.ts
+++ b/src/util/getReceiverAddress.ts
@@ -44,7 +44,7 @@ const getReceiverAddress = ({ receiverAddress, chain }: Props) => {
 
     const parts = rest?.split(',');
     const prefix = parts![2].split(' ');
-    const formatFound = getFormat(prefix[2]);
+    const formatFound = getFormat(prefix[2]) || prefix[2];
 
     const address = getDeriveAccount({
       SS58Format,


### PR DESCRIPTION
This is an initial approach for the generic account behavior.
There is no UX applied for letting the user know that the native and derived accounts are selectable. @goldsteinsveta  could you please take care of it? if there is anything i can do about it in this PR to make it look better just let me know. 