### PR TITLE
Unify account display a bit

### DIFF
--- a/src/actions/transactionActions.ts
+++ b/src/actions/transactionActions.ts
@@ -19,6 +19,7 @@ import { TransanctionStatus, UpdatedTransanctionStatus } from '../types/transact
 enum TransactionActionTypes {
   SET_ESTIMATED_FEE = 'SET_ESTIMATED_FEE',
   SET_RECEIVER_ADDRESS = 'SET_RECEIVER_ADDRESS',
+  SET_UNFORMATTED_RECEIVER_ADDRESS = 'SET_UNFORMATTED_RECEIVER_ADDRESS',
   CREATE_TRANSACTION_STATUS = 'CREATE_TRANSACTION_STATUS',
   UPDATE_CURRENT_TRANSACTION_STATUS = 'UPDATE_CURRENT_TRANSACTION_STATUS',
   SET_TRANSACTION_COMPLETED = 'SET_TRANSACTION_COMPLETED',
@@ -35,6 +36,11 @@ const estimateFee = (estimatedFee: string) => ({
 const setReceiverAddress = (receiverAddress: string | null) => ({
   payload: { receiverAddress },
   type: TransactionActionTypes.SET_RECEIVER_ADDRESS
+});
+
+const setUnformattedReceiverAddress = (unformattedReceiverAddress: string | null) => ({
+  payload: { unformattedReceiverAddress },
+  type: TransactionActionTypes.SET_UNFORMATTED_RECEIVER_ADDRESS
 });
 
 const createTransactionStatus = (initialTransaction: TransanctionStatus) => {
@@ -65,6 +71,7 @@ const TransactionActionCreators = {
   createTransactionStatus,
   estimateFee,
   setReceiverAddress,
+  setUnformattedReceiverAddress,
   updateTransactionStatus,
   setGenericAccount,
   setDerivedAccount

--- a/src/components/Account.tsx
+++ b/src/components/Account.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 
 import useApiBalance from '../hooks/useApiBalance';
 import useBalance from '../hooks/useBalance';
-import AccountDisplay from './AccountDisplay';
+import AccountDisplay, { AddressKind } from './AccountDisplay';
 
 interface Props {
   accountName?: string;
@@ -40,7 +40,7 @@ const Account = ({ accountName, value, chain, hideAddress = false, isDerived = f
       friendlyName={accountName}
       address={address}
       balance={state.formattedBalance}
-      addressKind={isDerived ? 'companion' : undefined}
+      addressKind={isDerived ? AddressKind.COMPANION : undefined}
       hideAddress={hideAddress}
     />
   );

--- a/src/components/Account.tsx
+++ b/src/components/Account.tsx
@@ -21,25 +21,27 @@ import useBalance from '../hooks/useBalance';
 import AccountDisplay from './AccountDisplay';
 
 interface Props {
-  value: string;
   accountName?: string;
-  className?: string;
   chain?: string | undefined;
+  className?: string;
+  hideAddress?: boolean;
   isDerived?: boolean;
   onClick?: () => void;
+  value: string;
 }
 
-const Account = ({ accountName, value, chain, isDerived = false }: Props) => {
+const Account = ({ accountName, value, chain, hideAddress = false, isDerived = false }: Props) => {
   const { api, address } = useApiBalance(value, chain, isDerived);
 
   const state = useBalance(api, address, true);
 
   return (
     <AccountDisplay
-      accountName={accountName}
+      friendlyName={accountName}
       address={address}
       balance={state.formattedBalance}
-      isDerived={isDerived}
+      addressKind={isDerived ? 'companion' : undefined}
+      hideAddress={hideAddress}
     />
   );
 };

--- a/src/components/AccountDisplay.tsx
+++ b/src/components/AccountDisplay.tsx
@@ -25,7 +25,7 @@ import shorterItem from '../util/shortenItem';
 import AccountIdenticon from './AccountIdenticon';
 
 interface Props {
-  addressKind?: 'companion' | 'native' | string;
+  addressKind?: AddressKind | string;
   address?: string;
   friendlyName?: string | null;
   hideAddress?: boolean;
@@ -87,5 +87,10 @@ const AccountDisplay = ({ address = '', addressKind, balance, friendlyName, hide
     </Container>
   );
 };
+
+export enum AddressKind {
+  NATIVE = 'native',
+  COMPANION = 'companion'
+}
 
 export default AccountDisplay;

--- a/src/components/AccountDisplay.tsx
+++ b/src/components/AccountDisplay.tsx
@@ -25,9 +25,10 @@ import shorterItem from '../util/shortenItem';
 import AccountIdenticon from './AccountIdenticon';
 
 interface Props {
+  addressKind?: 'companion' | 'native' | string;
   address?: string;
-  accountName?: string | null;
-  isDerived?: boolean;
+  friendlyName?: string | null;
+  hideAddress?: boolean;
   onClick?: () => void;
   balance?: string | null | undefined;
 }
@@ -58,24 +59,27 @@ const useStyles = makeStyles(() => ({
   }
 }));
 
-const AccountDisplay = ({ accountName, address = '', balance, isDerived = false, onClick }: Props) => {
+const AccountDisplay = ({ address = '', addressKind, balance, friendlyName, hideAddress = false, onClick }: Props) => {
   const classes = useStyles();
   const displayText = () => {
     if (!address) {
       return '';
     }
-    if (isDerived) {
-      return `Derived (${accountName || shorterItem(address)})`;
+    const shortAddress = shorterItem(address);
+    const name = friendlyName ? `${friendlyName} [${shortAddress}]` : shortAddress;
+    const justFriendlyName = friendlyName || shortAddress;
+    const displayName = hideAddress ? justFriendlyName : name;
+
+    if (addressKind) {
+      return `${addressKind}(${displayName})`;
     }
-    if (accountName) {
-      return `${accountName} (${shorterItem(address)})`;
-    }
-    return shorterItem(address);
+
+    return name;
   };
 
   return (
     <Container onClick={onClick} className={classes.container}>
-      <div className={classes.icon}>{(!isDerived || address) && <AccountIdenticon address={address} />}</div>
+      <div className={classes.icon}>{address && <AccountIdenticon address={address} />}</div>
       <div className={classes.address}>
         <p>{displayText()}</p>
       </div>

--- a/src/components/GenericAccount.tsx
+++ b/src/components/GenericAccount.tsx
@@ -24,6 +24,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import { useSourceTarget } from '../contexts/SourceTargetContextProvider';
 import useBalance from '../hooks/useBalance';
 import getDeriveAccount from '../util/getDeriveAccount';
+import shorterItem from '../util/shortenItem';
 import AccountDisplay from './AccountDisplay';
 
 interface Props {
@@ -59,13 +60,12 @@ const GenericAccount = ({ value }: Props) => {
     targetChainDetails: {
       targetApiConnection: { api: targetApi },
       targetChain
-    },
-    sourceChainDetails: { sourceChain }
+    }
   } = useSourceTarget();
 
   const { dispatchTransaction } = useUpdateTransactionContext();
   const chainsConfigs = getChainConfigs();
-  const { bridgeId } = chainsConfigs[sourceChain];
+  const { bridgeId } = chainsConfigs[targetChain];
   const { SS58Format: targetSS58Format } = chainsConfigs[targetChain];
 
   const nativeAddress = encodeAddress(value, targetSS58Format);
@@ -88,16 +88,29 @@ const GenericAccount = ({ value }: Props) => {
     dispatchTransaction(TransactionActionCreators.setReceiverAddress(derivedAddress));
   };
 
+  const shortGenericAddress = shorterItem(value);
   return (
     <Container className={classes.container}>
       {(!selected || selected === NATIVE) && (
         <div className={classes.native} onClick={setNativeAsTarget}>
-          <AccountDisplay accountName="Native" address={nativeAddress} balance={nativeState.formattedBalance} />
+          <AccountDisplay
+            address={nativeAddress}
+            addressKind="native"
+            balance={nativeState.formattedBalance}
+            friendlyName={shortGenericAddress}
+            hideAddress
+          />
         </div>
       )}
       {(!selected || selected === DERIVED) && (
         <div className={classes.companion} onClick={setCompanionAsTarget}>
-          <AccountDisplay address={derivedAddress} isDerived balance={derivedState.formattedBalance} />
+          <AccountDisplay
+            address={derivedAddress}
+            addressKind="companion"
+            balance={derivedState.formattedBalance}
+            friendlyName={shortGenericAddress}
+            hideAddress
+          />
         </div>
       )}
     </Container>

--- a/src/components/GenericAccount.tsx
+++ b/src/components/GenericAccount.tsx
@@ -60,12 +60,13 @@ const GenericAccount = ({ value }: Props) => {
     targetChainDetails: {
       targetApiConnection: { api: targetApi },
       targetChain
-    }
+    },
+    sourceChainDetails: { sourceChain }
   } = useSourceTarget();
 
   const { dispatchTransaction } = useUpdateTransactionContext();
   const chainsConfigs = getChainConfigs();
-  const { bridgeId } = chainsConfigs[targetChain];
+  const { bridgeId } = chainsConfigs[sourceChain];
   const { SS58Format: targetSS58Format } = chainsConfigs[targetChain];
 
   const nativeAddress = encodeAddress(value, targetSS58Format);

--- a/src/components/GenericAccount.tsx
+++ b/src/components/GenericAccount.tsx
@@ -25,7 +25,7 @@ import { useSourceTarget } from '../contexts/SourceTargetContextProvider';
 import useBalance from '../hooks/useBalance';
 import getDeriveAccount from '../util/getDeriveAccount';
 import shorterItem from '../util/shortenItem';
-import AccountDisplay from './AccountDisplay';
+import AccountDisplay, { AddressKind } from './AccountDisplay';
 
 interface Props {
   value: string;
@@ -96,7 +96,7 @@ const GenericAccount = ({ value }: Props) => {
         <div className={classes.native} onClick={setNativeAsTarget}>
           <AccountDisplay
             address={nativeAddress}
-            addressKind="native"
+            addressKind={AddressKind.NATIVE}
             balance={nativeState.formattedBalance}
             friendlyName={shortGenericAddress}
             hideAddress
@@ -107,7 +107,7 @@ const GenericAccount = ({ value }: Props) => {
         <div className={classes.companion} onClick={setCompanionAsTarget}>
           <AccountDisplay
             address={derivedAddress}
-            addressKind="companion"
+            addressKind={AddressKind.COMPANION}
             balance={derivedState.formattedBalance}
             friendlyName={shortGenericAddress}
             hideAddress

--- a/src/components/ReceiverDerivedAccount.tsx
+++ b/src/components/ReceiverDerivedAccount.tsx
@@ -21,6 +21,7 @@ import { useTransactionContext } from '../contexts/TransactionContext';
 import Account from './Account';
 import AccountDisplay from './AccountDisplay';
 import GenericAccount from './GenericAccount';
+import shortenItem from '../util/shortenItem';
 
 const useStyles = makeStyles(() => ({
   derived: {
@@ -35,7 +36,12 @@ const useStyles = makeStyles(() => ({
 
 const ReceiverDerivedAccount = () => {
   const classes = useStyles();
-  const { genericReceiverAccount, derivedReceiverAccount, receiverAddress } = useTransactionContext();
+  const {
+    genericReceiverAccount,
+    derivedReceiverAccount,
+    receiverAddress,
+    unformattedReceiverAddress
+  } = useTransactionContext();
 
   const {
     targetChainDetails: { targetChain }
@@ -46,16 +52,23 @@ const ReceiverDerivedAccount = () => {
   }
 
   if (derivedReceiverAccount) {
+    const shortUnformattedReceiver = shortenItem(unformattedReceiverAddress || '');
     return (
       <div className={classes.derived}>
-        <Account value={receiverAddress!} chain={targetChain} isDerived />
+        <Account
+          accountName={shortUnformattedReceiver}
+          value={receiverAddress!}
+          chain={targetChain}
+          isDerived
+          hideAddress
+        />
       </div>
     );
   }
 
   return (
     <div className={classes.derived}>
-      <AccountDisplay isDerived />
+      <AccountDisplay addressKind="companion" />
     </div>
   );
 };

--- a/src/components/ReceiverDerivedAccount.tsx
+++ b/src/components/ReceiverDerivedAccount.tsx
@@ -19,7 +19,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import { useSourceTarget } from '../contexts/SourceTargetContextProvider';
 import { useTransactionContext } from '../contexts/TransactionContext';
 import Account from './Account';
-import AccountDisplay from './AccountDisplay';
+import AccountDisplay, { AddressKind } from './AccountDisplay';
 import GenericAccount from './GenericAccount';
 import shortenItem from '../util/shortenItem';
 
@@ -68,7 +68,7 @@ const ReceiverDerivedAccount = () => {
 
   return (
     <div className={classes.derived}>
-      <AccountDisplay addressKind="companion" />
+      <AccountDisplay addressKind={AddressKind.COMPANION} />
     </div>
   );
 };

--- a/src/components/ReceiverInput.tsx
+++ b/src/components/ReceiverInput.tsx
@@ -59,16 +59,15 @@ const useStyles = makeStyles(() => ({
 
 function ReceiverInput({ setError }: Props) {
   const classes = useStyles();
-  const [addressInput, setAddresInput] = useState('');
   const [formatFound, setFormatFound] = useState('');
   const [showBalance, setShowBalance] = useState(false);
 
-  const { setReceiver, validateAccount } = useReceiver();
+  const { setReceiver, setUnformattedReceiver, validateAccount } = useReceiver();
 
   const { dispatchTransaction } = useUpdateTransactionContext();
-  const { receiverAddress } = useTransactionContext();
+  const { receiverAddress, unformattedReceiverAddress } = useTransactionContext();
 
-  const { api, address } = useApiBalance(addressInput, formatFound, false);
+  const { api, address } = useApiBalance(unformattedReceiverAddress, formatFound, false);
 
   const state = useBalance(api, address, true);
 
@@ -89,14 +88,14 @@ function ReceiverInput({ setError }: Props) {
   useEffect(() => {
     if (prevTargetChain !== targetChain) {
       reset();
-      setAddresInput('');
+      setUnformattedReceiver('');
     }
-  }, [addressInput, prevTargetChain, receiverAddress, reset, targetChain]);
+  }, [unformattedReceiverAddress, setUnformattedReceiver, prevTargetChain, receiverAddress, reset, targetChain]);
 
   const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const receiver = event.target.value;
     reset();
-    setAddresInput(receiver);
+    setUnformattedReceiver(receiver);
     if (!receiver) {
       return;
     }
@@ -122,13 +121,13 @@ function ReceiverInput({ setError }: Props) {
     if (formatFound === sourceChain) {
       dispatchTransaction(TransactionActionCreators.setDerivedAccount(formattedAccount));
       setReceiver(receiver);
-      setShowBalance(true);
       return;
     }
 
     setError(`Unsupported address SS58 prefix: ${formatFound}`);
   };
 
+  const addressInput = unformattedReceiverAddress || '';
   return (
     <Container className={classes.container}>
       <div className={classes.row}>

--- a/src/components/Sender.tsx
+++ b/src/components/Sender.tsx
@@ -80,7 +80,7 @@ const Sender = ({ className }: Props) => {
       >
         <div className={classes.row}>
           <Account accountName={text} value={value} chain={source} />
-          <Account accountName={text} value={value} isDerived chain={target} />
+          <Account accountName={text} value={value} isDerived hideAddress chain={target} />
         </div>
       </MenuItem>
     ));
@@ -94,7 +94,7 @@ const Sender = ({ className }: Props) => {
       const text = getName(account);
       return <Account accountName={text} value={value} chain={sourceChain} />;
     }
-    return <AccountDisplay accountName="sender" />;
+    return <AccountDisplay friendlyName="Select sender account" hideAddress />;
   };
 
   return (
@@ -109,7 +109,9 @@ const Sender = ({ className }: Props) => {
       </div>
 
       <div className="derivedAccount">
-        {derivedAccount && <Account accountName={getName(account)} value={value} chain={targetChain} isDerived />}
+        {derivedAccount && (
+          <Account accountName={getName(account)} value={value} chain={targetChain} isDerived hideAddress />
+        )}
       </div>
     </Container>
   );

--- a/src/contexts/TransactionContext.tsx
+++ b/src/contexts/TransactionContext.tsx
@@ -51,6 +51,7 @@ export function TransactionContextProvider(props: TransactionContextProviderProp
     estimatedFee: null,
     genericReceiverAccount: null,
     receiverAddress: null,
+    unformattedReceiverAddress: null,
     transactions: []
   });
 

--- a/src/hooks/useReceiver.ts
+++ b/src/hooks/useReceiver.ts
@@ -28,10 +28,11 @@ export default function useReceiver() {
     targetChainDetails: { targetChain }
   } = useSourceTarget();
 
-  const setReceiverAddress = (address: string | null) =>
+  const setReceiver = (address: string | null) =>
     dispatchTransaction(TransactionActionCreators.setReceiverAddress(address));
 
-  const setReceiver = (address: string | null) => setReceiverAddress(address);
+  const setUnformattedReceiver = (address: string | null) =>
+    dispatchTransaction(TransactionActionCreators.setUnformattedReceiverAddress(address));
 
   const validateAccount = (receiver: string) => {
     try {
@@ -49,5 +50,5 @@ export default function useReceiver() {
     }
   };
 
-  return { setReceiver, validateAccount };
+  return { setReceiver, setUnformattedReceiver, validateAccount };
 }

--- a/src/hooks/useSendMessage.ts
+++ b/src/hooks/useSendMessage.ts
@@ -148,7 +148,6 @@ function useSendMessage({ isRunning, isValidCall, setIsRunning, input, type, wei
         return isRunning || !account;
         break;
       case TransactionTypes.TRANSFER:
-        console.log('asdf', receiverAddress, account);
         return isRunning || !receiverAddress || !account;
         break;
       case TransactionTypes.CUSTOM:

--- a/src/reducers/transactionReducer.ts
+++ b/src/reducers/transactionReducer.ts
@@ -48,6 +48,8 @@ export default function transactionReducer(state: TransactionState, action: Tran
       return { ...state, estimatedFee: action.payload.estimatedFee };
     case TransactionActionTypes.SET_RECEIVER_ADDRESS:
       return { ...state, receiverAddress: action.payload.receiverAddress };
+    case TransactionActionTypes.SET_UNFORMATTED_RECEIVER_ADDRESS:
+      return { ...state, unformattedReceiverAddress: action.payload.unformattedReceiverAddress };
     case TransactionActionTypes.CREATE_TRANSACTION_STATUS:
       return createTransaction(state, action.payload.initialTransaction);
     case TransactionActionTypes.UPDATE_CURRENT_TRANSACTION_STATUS:

--- a/src/types/transactionTypes.ts
+++ b/src/types/transactionTypes.ts
@@ -19,6 +19,7 @@ import { TransactionActionTypes } from '../actions/transactionActions';
 export interface TransactionContextType {
   estimatedFee: string | null;
   receiverAddress: string | null;
+  unformattedReceiverAddress: string | null;
   transactions: Array<TransanctionStatus>;
   derivedReceiverAccount: string | null;
   genericReceiverAccount: string | null;
@@ -51,6 +52,7 @@ export interface TransanctionStatus extends UpdatedTransanctionStatus {
 export interface TransactionState {
   estimatedFee: string | null;
   receiverAddress: string | null;
+  unformattedReceiverAddress: string | null;
   derivedReceiverAccount: string | null;
   genericReceiverAccount: string | null;
   transactions: Array<TransanctionStatus>;


### PR DESCRIPTION
This PR is there to make sure that a bunch of conditions are always satisfied:
1. We use consistent `native/companion` naming
2. In case of generic address the values in selection box can be related to original input (i.e. `native(<originalinput>) and companion(<originalinput>)`).
3. We don't display accounts for generic address, cause it doesn't make sense (the user haven't decided what kind of account it is yet).
![image](https://user-images.githubusercontent.com/581548/116784446-80ef9a00-aa94-11eb-9380-08b99ed7563a.png)
