### PR TITLE
Fix call encoding (again)

### DIFF
--- a/src/hooks/useSendMessage.ts
+++ b/src/hooks/useSendMessage.ts
@@ -72,7 +72,7 @@ function useSendMessage({ isRunning, isValidCall, setIsRunning, input, type, wei
 
       const { bridgedMessages } = getSubstrateDynamicNames(targetChain);
       const bridgeMessage = sourceApi.tx[bridgedMessages].sendMessage(laneId, payload, estimatedFee);
-      logger.info('bridge::sendMessage', bridgeMessage.toHex());
+      logger.info(`bridge::sendMessage ${bridgeMessage.toHex()}`);
       const options: Partial<SignerOptions> = {
         nonce: -1
       };

--- a/src/hooks/useTransactionType.ts
+++ b/src/hooks/useTransactionType.ts
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
 
-import { hexToU8a, isHex } from '@polkadot/util';
+import { hexToU8a, isHex, u8aToHex } from '@polkadot/util';
 import { useEffect, useState } from 'react';
 
 import { useAccountContext } from '../contexts/AccountContextProvider';
@@ -55,28 +55,27 @@ export default function useTransactionType({ input, type, weightInput }: Props):
 
   useEffect(() => {
     async function getValues() {
-      let paymentInfo, apiCall;
-      let weight = null;
-      let call = null;
+      let weight: number = 0;
+      let call: Uint8Array | null = null;
 
       if (account) {
         switch (type) {
           case TransactionTypes.REMARK:
-            paymentInfo = await targetApi.tx.system.remark(input).paymentInfo(account);
-            apiCall = await targetApi.tx.system.remark(input);
-            logger.info(`system::remark: ${apiCall.toHex()}`);
+            call = (await targetApi.tx.system.remark(input)).toU8a();
+            logger.info(`system::remark: ${u8aToHex(call)}`);
             // TODO [#121] Figure out what the extra bytes are about
-            call = apiCall.toU8a().slice(2);
-            weight = paymentInfo.weight.toNumber();
+            call = call.slice(2);
+            weight = (await targetApi.tx.system.remark(input).paymentInfo(account)).weight.toNumber();
             break;
           case TransactionTypes.TRANSFER:
             if (receiverAddress) {
-              apiCall = await targetApi.tx.balances.transfer(receiverAddress, input);
-              paymentInfo = await targetApi.tx.balances.transfer(receiverAddress, input).paymentInfo(account);
-              logger.info(`balances::transfer: ${apiCall.toHex()}`);
+              call = (await targetApi.tx.balances.transfer(receiverAddress, input)).toU8a();
+              logger.info(`balances::transfer: ${u8aToHex(call)}`);
               // TODO [#121] Figure out what the extra bytes are about
-              call = apiCall.toU8a().slice(2);
-              weight = paymentInfo.weight.toNumber();
+              call = call.slice(2);
+              weight = (
+                await targetApi.tx.balances.transfer(receiverAddress, input).paymentInfo(account)
+              ).weight.toNumber();
             }
             break;
           case TransactionTypes.CUSTOM:

--- a/src/hooks/useTransactionType.ts
+++ b/src/hooks/useTransactionType.ts
@@ -55,16 +55,15 @@ export default function useTransactionType({ input, type, weightInput }: Props):
 
   useEffect(() => {
     async function getValues() {
-      let apiPromise, paymentInfo, apiCall;
+      let paymentInfo, apiCall;
       let weight = null;
       let call = null;
 
       if (account) {
         switch (type) {
           case TransactionTypes.REMARK:
-            apiPromise = targetApi.tx.system.remark(input);
-            paymentInfo = await apiPromise.paymentInfo(account);
-            apiCall = await apiPromise;
+            paymentInfo = await targetApi.tx.system.remark(input).paymentInfo(account);
+            apiCall = await targetApi.tx.system.remark(input);
             logger.info(`system::remark: ${apiCall.toHex()}`);
             // TODO [#121] Figure out what the extra bytes are about
             call = apiCall.toU8a().slice(2);
@@ -72,9 +71,8 @@ export default function useTransactionType({ input, type, weightInput }: Props):
             break;
           case TransactionTypes.TRANSFER:
             if (receiverAddress) {
-              apiPromise = targetApi.tx.balances.transfer(receiverAddress, input);
-              paymentInfo = await apiPromise.paymentInfo(account);
-              apiCall = await apiPromise;
+              apiCall = await targetApi.tx.balances.transfer(receiverAddress, input);
+              paymentInfo = await targetApi.tx.balances.transfer(receiverAddress, input).paymentInfo(account);
               logger.info(`balances::transfer: ${apiCall.toHex()}`);
               // TODO [#121] Figure out what the extra bytes are about
               call = apiCall.toU8a().slice(2);


### PR DESCRIPTION
This is a follow up on #123.

Initially when I was testing the UI I used a more verbose form (like below). Before making a PR I decided to avoid duplicating of method calls and cache the result in `apiPromise`.

Looks like for some reason this is actually broken, and returns a completely different call, so I suspect the same object cannot be used for both `transactionPayment` chain and regular transfer call.