### PR TITLE
AsyncState hook for update state only when component is mounted

### DIFF
--- a/src/hooks/useMountedState.ts
+++ b/src/hooks/useMountedState.ts
@@ -17,6 +17,20 @@
 import { useState } from 'react';
 import { useIsMounted } from './useIsMounted';
 
+/**
+ * Like React's [useState](https://reactjs.org/docs/hooks-reference.html#usestate)
+ * but it makes sure the component that uses this state hook is mounted before updating state
+ *
+ * @see https://reactjs.org/docs/hooks-reference.html#usestate
+ * @export
+ * @param {D} initialValue
+ * @returns {[D, Diapatch<D>]} an array of 2 items
+ * the first is the current state, the second is a function that enables
+ * updating the state if the component is not mounted
+ *
+ * D is the type passed when then useMountedState is used
+ * e.g. const [pass, setPass] = useMountedState<string>('someString');
+ */
 export const useMountedState = <D>(initialValue: D) => {
   const isMounted = useIsMounted();
 

--- a/src/hooks/useMountedState.ts
+++ b/src/hooks/useMountedState.ts
@@ -1,0 +1,32 @@
+// Copyright 2021 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges UI.
+//
+// Parity Bridges UI is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Parity Bridges UI is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
+
+import { useState } from 'react';
+import { useIsMounted } from './useIsMounted';
+
+export const useMountedState = <D>(initialValue: D) => {
+  const isMounted = useIsMounted();
+
+  const [state, setState] = useState<D>(initialValue);
+
+  const setMountedState = (value: D) => {
+    if (isMounted()) {
+      setState(value);
+    }
+  };
+
+  return [state, setMountedState];
+};


### PR DESCRIPTION
I have been thinking the PR #114 and the discussion I had with @tomusdrw about the isMounted and async calls as can be found here: https://github.com/paritytech/parity-bridges-ui/pull/129#pullrequestreview-650681805 and I realised that instead of having a "rule of thumb" that `inside an async/await to always make sure before updating the state to put first the isMounted hook` - it would be easier if we had a custom useState hook that would do that for us.

This PR is the outcome of the thought above.

Instead of:
```
import { useState } from 'react';
const [state, setState] = useState<State>(initValues);
....
isMounted() && setState({...
```
it makes it easier and faster to:
```
import { useMountedState } from './useMountedState';
const [state, setState] = useMountedState<State>(initValues);
....
setState({....
````
