### PR TITLE
Try again to fix usebalance leak

### DIFF
--- a/src/hooks/useBalance.ts
+++ b/src/hooks/useBalance.ts
@@ -19,7 +19,6 @@ import { Balance } from '@polkadot/types/interfaces';
 import { formatBalance } from '@polkadot/util';
 import BN from 'bn.js';
 import { useEffect } from 'react';
-import { useIsMounted } from './useIsMounted';
 
 import { useMountedState } from './useMountedState';
 
@@ -44,8 +43,6 @@ const initValues = {
 const useBalance = (api: ApiPromise, address: string, providedSi: boolean = false): State => {
   const { dispatchMessage } = useUpdateMessageContext();
   const [state, setState] = useMountedState<State>(initValues);
-
-  const isMounted = useIsMounted();
 
   useEffect((): (() => void) => {
     let unsubscribe: null | (() => void) = null;
@@ -72,7 +69,7 @@ const useBalance = (api: ApiPromise, address: string, providedSi: boolean = fals
     return (): void => {
       unsubscribe && unsubscribe();
     };
-  }, [address, providedSi, dispatchMessage, api, setState, isMounted]);
+  }, [address, providedSi, dispatchMessage, api, setState]);
 
   return state as State;
 };

--- a/src/hooks/useBalance.ts
+++ b/src/hooks/useBalance.ts
@@ -24,6 +24,8 @@ import { useIsMounted } from './useIsMounted';
 import { useMountedState } from './useMountedState';
 
 import { useUpdateMessageContext } from '../contexts/MessageContext';
+import { MessageActionsCreators } from '../actions/messageActions';
+import logger from '../util/logger';
 
 type State = {
   chainTokens: string;
@@ -62,7 +64,10 @@ const useBalance = (api: ApiPromise, address: string, providedSi: boolean = fals
       .then((u): void => {
         unsubscribe = u;
       })
-      .catch(console.error);
+      .catch((e) => {
+        dispatchMessage(MessageActionsCreators.triggerErrorMessage({ message: e.message }));
+        logger.error(e.message);
+      });
 
     return (): void => {
       unsubscribe && unsubscribe();

--- a/src/hooks/useBalance.ts
+++ b/src/hooks/useBalance.ts
@@ -19,12 +19,12 @@ import { VoidFn } from '@polkadot/api/types';
 import { Balance } from '@polkadot/types/interfaces';
 import { formatBalance } from '@polkadot/util';
 import BN from 'bn.js';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 import { MessageActionsCreators } from '../actions/messageActions';
 import { useUpdateMessageContext } from '../contexts/MessageContext';
 import logger from '../util/logger';
-import { useIsMounted } from './useIsMounted';
+import { useMountedState } from './useMountedState';
 
 type State = {
   chainTokens: string;
@@ -42,24 +42,21 @@ const initValues = {
 
 const useBalance = (api: ApiPromise, address: string, providedSi: boolean = false): State => {
   const { dispatchMessage } = useUpdateMessageContext();
-  const [state, setState] = useState<State>(initValues);
-
-  const isMounted = useIsMounted();
+  const [state, setState] = useMountedState<State>(initValues);
 
   useEffect((): (() => void) => {
     const getBalance = async (api: ApiPromise, address: string, setState: any): Promise<VoidFn> => {
       try {
         const u = await api.query.system.account(address, ({ data }): void => {
-          isMounted() &&
-            setState({
-              chainTokens: data.free.registry.chainTokens[0],
-              formattedBalance: formatBalance(data.free, {
-                decimals: api.registry.chainDecimals[0],
-                forceUnit: '-',
-                withSi: providedSi
-              }),
-              free: data.free
-            });
+          setState({
+            chainTokens: data.free.registry.chainTokens[0],
+            formattedBalance: formatBalance(data.free, {
+              decimals: api.registry.chainDecimals[0],
+              forceUnit: '-',
+              withSi: providedSi
+            }),
+            free: data.free
+          });
         });
         return Promise.resolve(u);
       } catch (e) {
@@ -77,7 +74,7 @@ const useBalance = (api: ApiPromise, address: string, providedSi: boolean = fals
     return async (): Promise<void> => {
       unsubscribe && (await unsubscribe)();
     };
-  }, [address, providedSi, dispatchMessage, api, setState, isMounted]);
+  }, [address, providedSi, dispatchMessage, api, setState]);
 
   return state as State;
 };

--- a/src/hooks/useBalance.ts
+++ b/src/hooks/useBalance.ts
@@ -18,8 +18,10 @@ import { ApiPromise } from '@polkadot/api';
 import { Balance } from '@polkadot/types/interfaces';
 import { formatBalance } from '@polkadot/util';
 import BN from 'bn.js';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useIsMounted } from './useIsMounted';
+
+import { useMountedState } from './useMountedState';
 
 import { useUpdateMessageContext } from '../contexts/MessageContext';
 
@@ -39,26 +41,23 @@ const initValues = {
 
 const useBalance = (api: ApiPromise, address: string, providedSi: boolean = false): State => {
   const { dispatchMessage } = useUpdateMessageContext();
-  const [state, setState] = useState<State>(initValues);
+  const [state, setState] = useMountedState<State>(initValues);
 
   const isMounted = useIsMounted();
-
-  console.log('leak?');
 
   useEffect((): (() => void) => {
     let unsubscribe: null | (() => void) = null;
     api?.query?.system
       .account(address, ({ data }): void => {
-        isMounted() &&
-          setState({
-            chainTokens: data.free.registry.chainTokens[0],
-            formattedBalance: formatBalance(data.free, {
-              decimals: api.registry.chainDecimals[0],
-              forceUnit: '-',
-              withSi: providedSi
-            }),
-            free: data.free
-          });
+        setState({
+          chainTokens: data.free.registry.chainTokens[0],
+          formattedBalance: formatBalance(data.free, {
+            decimals: api.registry.chainDecimals[0],
+            forceUnit: '-',
+            withSi: providedSi
+          }),
+          free: data.free
+        });
       })
       .then((u): void => {
         unsubscribe = u;

--- a/src/hooks/useBalance.ts
+++ b/src/hooks/useBalance.ts
@@ -15,16 +15,16 @@
 // along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
 
 import { ApiPromise } from '@polkadot/api';
+import { VoidFn } from '@polkadot/api/types';
 import { Balance } from '@polkadot/types/interfaces';
 import { formatBalance } from '@polkadot/util';
 import BN from 'bn.js';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
-import { useMountedState } from './useMountedState';
-
-import { useUpdateMessageContext } from '../contexts/MessageContext';
 import { MessageActionsCreators } from '../actions/messageActions';
+import { useUpdateMessageContext } from '../contexts/MessageContext';
 import logger from '../util/logger';
+import { useIsMounted } from './useIsMounted';
 
 type State = {
   chainTokens: string;
@@ -42,34 +42,42 @@ const initValues = {
 
 const useBalance = (api: ApiPromise, address: string, providedSi: boolean = false): State => {
   const { dispatchMessage } = useUpdateMessageContext();
-  const [state, setState] = useMountedState<State>(initValues);
+  const [state, setState] = useState<State>(initValues);
+
+  const isMounted = useIsMounted();
 
   useEffect((): (() => void) => {
-    let unsubscribe: null | (() => void) = null;
-    api?.query?.system
-      .account(address, ({ data }): void => {
-        setState({
-          chainTokens: data.free.registry.chainTokens[0],
-          formattedBalance: formatBalance(data.free, {
-            decimals: api.registry.chainDecimals[0],
-            forceUnit: '-',
-            withSi: providedSi
-          }),
-          free: data.free
+    const getBalance = async (api: ApiPromise, address: string, setState: any): Promise<VoidFn> => {
+      try {
+        const u = await api.query.system.account(address, ({ data }): void => {
+          isMounted() &&
+            setState({
+              chainTokens: data.free.registry.chainTokens[0],
+              formattedBalance: formatBalance(data.free, {
+                decimals: api.registry.chainDecimals[0],
+                forceUnit: '-',
+                withSi: providedSi
+              }),
+              free: data.free
+            });
         });
-      })
-      .then((u): void => {
-        unsubscribe = u;
-      })
-      .catch((e) => {
+        return Promise.resolve(u);
+      } catch (e) {
         dispatchMessage(MessageActionsCreators.triggerErrorMessage({ message: e.message }));
         logger.error(e.message);
-      });
-
-    return (): void => {
-      unsubscribe && unsubscribe();
+        return Promise.reject();
+      }
     };
-  }, [address, providedSi, dispatchMessage, api, setState]);
+
+    let unsubscribe: Promise<VoidFn>;
+
+    if (address) {
+      unsubscribe = getBalance(api, address, setState);
+    }
+    return async (): Promise<void> => {
+      unsubscribe && (await unsubscribe)();
+    };
+  }, [address, providedSi, dispatchMessage, api, setState, isMounted]);
 
   return state as State;
 };

--- a/src/hooks/useMountedState.ts
+++ b/src/hooks/useMountedState.ts
@@ -31,10 +31,10 @@ import { useIsMounted } from './useIsMounted';
  * D is the type passed when then useMountedState is used
  * e.g. const [pass, setPass] = useMountedState<string>('someString');
  */
-export const useMountedState = <D>(initialValue: D) => {
+export const useMountedState = <D>(initialState: D | (() => D)) => {
   const isMounted = useIsMounted();
 
-  const [state, setState] = useState<D>(initialValue);
+  const [state, setState] = useState<D>(initialState);
 
   const setMountedState = (value: D) => {
     if (isMounted()) {

--- a/src/hooks/useMountedState.ts
+++ b/src/hooks/useMountedState.ts
@@ -42,5 +42,5 @@ export const useMountedState = <D>(initialState: D | (() => D)) => {
     }
   };
 
-  return [state, setMountedState];
+  return [state, setMountedState] as const;
 };

--- a/src/hooks/useMountedState.ts
+++ b/src/hooks/useMountedState.ts
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
 
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useIsMounted } from './useIsMounted';
 
 /**
@@ -36,11 +36,14 @@ export const useMountedState = <D>(initialState: D | (() => D)) => {
 
   const [state, setState] = useState<D>(initialState);
 
-  const setMountedState = (value: D) => {
-    if (isMounted()) {
-      setState(value);
-    }
-  };
+  const setMountedState = useCallback(
+    (value: D) => {
+      if (isMounted()) {
+        setState(value);
+      }
+    },
+    [isMounted]
+  );
 
   return [state, setMountedState] as const;
 };


### PR DESCRIPTION
Memory leak was coming from useMountedState.
There is something in that custom hook that was triggering loops (irrelevant completely to how the useEffect is written - chain   promise or async/await).
Will investigate in different PR how to make the useMountedState usable instead of using isMounted && setState - but for now I would like to fix the memory leak.