### PR TITLE
Fixing  steps inconsistences.

### DIFF
--- a/src/hooks/useTransactionNonces.ts
+++ b/src/hooks/useTransactionNonces.ts
@@ -35,6 +35,7 @@ interface Props {
 
 const useTransactionNonces = ({ transaction }: Props) => {
   const [latestReceivedNonceRuntimeApi, setLatestReceivedNonceRuntimeApi] = useMountedState(0);
+  const [nonceOfCurrentTargetBlock, setNonceOfCurrentTargetBlock] = useMountedState<null | number>(null);
   const { getValuesByChain } = useChainGetters();
 
   const laneId = useLaneId();
@@ -79,6 +80,12 @@ const useTransactionNonces = ({ transaction }: Props) => {
       setLatestReceivedNonceRuntimeApi(parseInt(latestReceivedNonceCallType.toString()));
     };
 
+    const getNonceOfCurrentBlock = async () => {
+      const nonce = await getNonceByHash(parseInt(bestBlockFinalizedOnTarget));
+      setNonceOfCurrentTargetBlock(nonce);
+    };
+
+    getNonceOfCurrentBlock();
     getLatestReceivedNonce();
   }, [
     areApiLoading,
@@ -89,10 +96,12 @@ const useTransactionNonces = ({ transaction }: Props) => {
     targetApi.registry,
     targetApi.rpc.chain,
     targetApi.rpc.state,
-    setLatestReceivedNonceRuntimeApi
+    setLatestReceivedNonceRuntimeApi,
+    getNonceByHash,
+    setNonceOfCurrentTargetBlock
   ]);
 
-  return { getNonceByHash, latestReceivedNonceRuntimeApi };
+  return { getNonceByHash, latestReceivedNonceRuntimeApi, nonceOfCurrentTargetBlock };
 };
 
 export default useTransactionNonces;


### PR DESCRIPTION
Transaction steps were being incorrectly being updated due to a regression introduced in PR #140.

This PR fixes the current behavior that  step `Finalize message in target block` was never completing even when last step is ready. After these fixes i was not able to reproduce again the issue that `Delivered Message` gets finished before the Relay message.  

What it is not solving is: Balance gets updated before delivered message step is finished.  I'm tempted to think that the reason of this issue is because the delivered message step is related to reading the storage related with the bridge and reading balance is a different process as far as i understand ( @tomusdrw can you see any more specific scenario based on my assumption ? )