### PR TITLE
Fix how UI reacts when APIs are not connected

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,13 +27,14 @@ import { SourceTargetContextProvider } from './contexts/SourceTargetContextProvi
 import { TransactionContextProvider } from './contexts/TransactionContext';
 import { useConnections } from './hooks/useConnections';
 import Main from './screens/Main';
+import { isEmpty } from 'lodash';
 
 const [connectionDetails1, connectionDetails2] = substrateProviders();
 
 function App() {
   const { connections } = useConnections([connectionDetails1, connectionDetails2]);
 
-  if (Object.keys(connections).length === 0) {
+  if (isEmpty(connections)) {
     return (
       <Backdrop open>
         <CircularProgress color="inherit" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,14 +27,13 @@ import { SourceTargetContextProvider } from './contexts/SourceTargetContextProvi
 import { TransactionContextProvider } from './contexts/TransactionContext';
 import { useConnections } from './hooks/useConnections';
 import Main from './screens/Main';
-import { isEmpty } from 'lodash';
 
 const [connectionDetails1, connectionDetails2] = substrateProviders();
 
 function App() {
   const { connections } = useConnections([connectionDetails1, connectionDetails2]);
 
-  if (isEmpty(connections)) {
+  if (Object.keys(connections).length === 0) {
     return (
       <Backdrop open>
         <CircularProgress color="inherit" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,13 +27,14 @@ import { SourceTargetContextProvider } from './contexts/SourceTargetContextProvi
 import { TransactionContextProvider } from './contexts/TransactionContext';
 import { useConnections } from './hooks/useConnections';
 import Main from './screens/Main';
+import { isEmpty } from 'lodash';
 
 const [connectionDetails1, connectionDetails2] = substrateProviders();
 
 function App() {
-  const { connections, apiReady } = useConnections([connectionDetails1, connectionDetails2]);
+  const { connections } = useConnections([connectionDetails1, connectionDetails2]);
 
-  if (!apiReady) {
+  if (isEmpty(connections)) {
     return (
       <Backdrop open>
         <CircularProgress color="inherit" />

--- a/src/components/CustomCall.tsx
+++ b/src/components/CustomCall.tsx
@@ -20,7 +20,6 @@ import { Message } from 'semantic-ui-react';
 import { ButtonSubmit } from '../components';
 import { useSourceTarget } from '../contexts/SourceTargetContextProvider';
 import { useTransactionContext } from '../contexts/TransactionContext';
-import useLoadingApi from '../hooks/useLoadingApi';
 import useSendMessage from '../hooks/useSendMessage';
 import { TransactionTypes } from '../types/transactionTypes';
 
@@ -33,7 +32,6 @@ const CustomCall = () => {
   const [error, setError] = useState<string | null>();
   const { sourceChainDetails, targetChainDetails } = useSourceTarget();
 
-  const areApiReady = useLoadingApi();
   const { estimatedFee } = useTransactionContext();
   const {
     targetChainDetails: {
@@ -57,10 +55,6 @@ const CustomCall = () => {
   const onWeightChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setWeightInput(event.target.value);
   };
-
-  if (!areApiReady) {
-    return null;
-  }
 
   function decodePayload(input: string) {
     try {

--- a/src/components/ExtensionAccountCheck.tsx
+++ b/src/components/ExtensionAccountCheck.tsx
@@ -22,12 +22,12 @@ interface Props {
   component: JSX.Element;
 }
 
-// TODO: Move this to a more generic error-show component
+// TODO #176: Move this to a more generic error-show component
 const statusFunc = (from: string, state: boolean) => `${from} chain status: ${!state ? 'disconnected' : 'connected'}`;
 
 const ExtensionAccountCheck = ({ component }: Props): JSX.Element => {
   const { extensionExists, accountExists } = useKeyringContext();
-  // TODO: Move this to a more generic error-show component
+  // TODO #176: Move this to a more generic error-show component
   const { sourceReady, targetReady } = useLoadingApi();
 
   let msg: string = '';
@@ -35,7 +35,7 @@ const ExtensionAccountCheck = ({ component }: Props): JSX.Element => {
     msg = 'Connect to a wallet. Install polkadotjs extension';
   } else if (!accountExists) {
     msg = 'There are no accounts in the extension. Please create one';
-    // TODO: Move this to a more generic error-show component
+    // TODO #176: Move this to a more generic error-show component
   } else if (!sourceReady || !targetReady) {
     msg = `${!sourceReady ? statusFunc('Source', sourceReady) : ''} ${
       !targetReady ? statusFunc('Target', targetReady) : ''

--- a/src/components/ExtensionAccountCheck.tsx
+++ b/src/components/ExtensionAccountCheck.tsx
@@ -42,7 +42,7 @@ const ExtensionAccountCheck = ({ component }: Props): JSX.Element => {
     }`;
   }
 
-  return <>{accountExists && sourceReady && targetReady ? component : <Alert severity="error">{msg}</Alert>}</>;
+  return <>{msg ? <Alert severity="error">{msg}</Alert> : component}</>;
 };
 
 export default ExtensionAccountCheck;

--- a/src/components/ExtensionAccountCheck.tsx
+++ b/src/components/ExtensionAccountCheck.tsx
@@ -23,12 +23,12 @@ interface Props {
 }
 
 // TODO: Move this to a more generic error-show component
-const statusFunc = (from: string, state: boolean) => `${from} status: ${!state && 'dis'}connected.`;
+const statusFunc = (from: string, state: boolean) => `${from} chain status: ${!state ? 'disconnected' : 'connected'}`;
 
 const ExtensionAccountCheck = ({ component }: Props): JSX.Element => {
   const { extensionExists, accountExists } = useKeyringContext();
   // TODO: Move this to a more generic error-show component
-  const { areApiReady, sourceReady, targetReady } = useLoadingApi();
+  const { sourceReady, targetReady } = useLoadingApi();
 
   let msg: string = '';
   if (!extensionExists) {
@@ -36,11 +36,13 @@ const ExtensionAccountCheck = ({ component }: Props): JSX.Element => {
   } else if (!accountExists) {
     msg = 'There are no accounts in the extension. Please create one';
     // TODO: Move this to a more generic error-show component
-  } else if (!areApiReady) {
-    msg = `${statusFunc('Source', sourceReady)} ${statusFunc('Target', targetReady)}`;
+  } else if (!sourceReady || !targetReady) {
+    msg = `${!sourceReady ? statusFunc('Source', sourceReady) : ''} ${
+      !targetReady ? statusFunc('Target', targetReady) : ''
+    }`;
   }
 
-  return <>{accountExists && areApiReady ? component : <Alert severity="error">{msg}</Alert>}</>;
+  return <>{accountExists && sourceReady && targetReady ? component : <Alert severity="error">{msg}</Alert>}</>;
 };
 
 export default ExtensionAccountCheck;

--- a/src/components/ExtensionAccountCheck.tsx
+++ b/src/components/ExtensionAccountCheck.tsx
@@ -16,22 +16,31 @@
 import React from 'react';
 import { Alert } from '.';
 import { useKeyringContext } from '../contexts/KeyringContextProvider';
+import useLoadingApi from '../hooks/useLoadingApi';
 
 interface Props {
   component: JSX.Element;
 }
 
+// TODO: Move this to a more generic error-show component
+const statusFunc = (from: string, state: boolean) => `${from} status: ${!state && 'dis'}connected.`;
+
 const ExtensionAccountCheck = ({ component }: Props): JSX.Element => {
   const { extensionExists, accountExists } = useKeyringContext();
+  // TODO: Move this to a more generic error-show component
+  const { areApiReady, sourceReady, targetReady } = useLoadingApi();
 
   let msg: string = '';
   if (!extensionExists) {
     msg = 'Connect to a wallet. Install polkadotjs extension';
   } else if (!accountExists) {
     msg = 'There are no accounts in the extension. Please create one';
+    // TODO: Move this to a more generic error-show component
+  } else if (!areApiReady) {
+    msg = `${statusFunc('Source', sourceReady)} ${statusFunc('Target', targetReady)}`;
   }
 
-  return <>{accountExists ? component : <Alert severity="error">{msg}</Alert>}</>;
+  return <>{accountExists && areApiReady ? component : <Alert severity="error">{msg}</Alert>}</>;
 };
 
 export default ExtensionAccountCheck;

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
 
+import { makeStyles } from '@material-ui/core/styles';
 import AutorenewIcon from '@material-ui/icons/Autorenew';
 import CheckCircleOutlineIcon from '@material-ui/icons/CheckCircleOutline';
 import ErrorOutlineIcon from '@material-ui/icons/ErrorOutline';
@@ -23,8 +24,22 @@ import React from 'react';
 
 import { TransactionStatusEnum } from '../types/transactionTypes';
 
+const useStyles = makeStyles((theme) => ({
+  error: {
+    color: theme.palette.error.main
+  },
+  success: {
+    color: theme.palette.success.main
+  }
+}));
+
 interface IconTxStatusProps {
   status: keyof typeof TransactionStatusEnum;
+}
+
+interface IconApiStatusProps {
+  status: boolean;
+  className?: string;
 }
 export const IconTxStatus = ({ status }: IconTxStatusProps) => {
   switch (status) {
@@ -39,4 +54,9 @@ export const IconTxStatus = ({ status }: IconTxStatusProps) => {
     default:
       return <FiberManualRecordIcon />;
   }
+};
+
+export const IconApiStatus = ({ status, className }: IconApiStatusProps) => {
+  const classes = useStyles();
+  return <FiberManualRecordIcon className={`${status ? classes.success : classes.error} ${className}`} />;
 };

--- a/src/components/Network.tsx
+++ b/src/components/Network.tsx
@@ -21,6 +21,8 @@ import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
 import { useSourceTarget } from '../contexts/SourceTargetContextProvider';
 import useDashboard from '../hooks/useDashboard';
 import { ChainDetails } from '../types/sourceTargetTypes';
+import useLoadingApi from '../hooks/useLoadingApi';
+import { IconApiStatus } from './Icons';
 
 // As this is placed as a child in the Material UI Select component, for some reason style components classes are not working.
 // This way to inject the styles works.
@@ -50,6 +52,11 @@ const useStyles = makeStyles((theme) => ({
     '& span': {
       ...theme.typography.subtitle2
     }
+  },
+  svg: {
+    marginBottom: '0.2em',
+    fontSize: '0.5em',
+    marginRight: theme.spacing()
   }
 }));
 
@@ -58,11 +65,13 @@ export const NetworkSides = () => {
   const { sourceChainDetails, targetChainDetails } = useSourceTarget();
   const dbSource = useDashboard(ChainDetails.SOURCE);
   const dbTarget = useDashboard(ChainDetails.TARGET);
+  const { sourceReady, targetReady } = useLoadingApi();
 
   return (
     <Box marginY={2} className={classes.main}>
       <Box p={1} className={classes.statsEntry}>
         <Typography variant="h4">
+          <IconApiStatus className={classes.svg} status={sourceReady} />
           <a target="_blank" rel="noreferrer" href={sourceChainDetails.sourcePolkadotjsUrl}>
             {sourceChainDetails.sourceChain}
           </a>
@@ -75,6 +84,7 @@ export const NetworkSides = () => {
       </IconButton>
       <Box p={1} className={classes.statsEntry}>
         <Typography variant="h4">
+          <IconApiStatus className={classes.svg} status={targetReady} />
           <a target="_blank" rel="noreferrer" href={targetChainDetails.targetPolkadotjsUrl}>
             {targetChainDetails.targetChain}
           </a>

--- a/src/components/Remark.tsx
+++ b/src/components/Remark.tsx
@@ -19,7 +19,6 @@ import React, { useState } from 'react';
 import { ButtonSubmit } from '../components';
 import { useSourceTarget } from '../contexts/SourceTargetContextProvider';
 import { useTransactionContext } from '../contexts/TransactionContext';
-import useLoadingApi from '../hooks/useLoadingApi';
 import useSendMessage from '../hooks/useSendMessage';
 import { TransactionTypes } from '../types/transactionTypes';
 
@@ -28,7 +27,6 @@ const Remark = () => {
   const [remarkInput, setRemarkInput] = useState('0x');
   const { sourceChainDetails, targetChainDetails } = useSourceTarget();
 
-  const areApiReady = useLoadingApi();
   const { estimatedFee } = useTransactionContext();
 
   const { isButtonDisabled, sendLaneMessage } = useSendMessage({
@@ -40,10 +38,6 @@ const Remark = () => {
   const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setRemarkInput(event.target.value);
   };
-
-  if (!areApiReady) {
-    return null;
-  }
 
   return (
     <>

--- a/src/components/Sender.tsx
+++ b/src/components/Sender.tsx
@@ -22,6 +22,7 @@ import React, { useEffect, useState } from 'react';
 import { useSourceTarget } from '../contexts/SourceTargetContextProvider';
 import useAccounts from '../hooks/useAccounts';
 import useReceiver from '../hooks/useReceiver';
+import useLoadingApi from '../hooks/useLoadingApi';
 import { Account as AccountType } from '../types/accountTypes';
 import formatAccounts from '../util/formatAccounts';
 import Account from './Account';
@@ -79,6 +80,8 @@ const Sender = () => {
   const { setReceiver } = useReceiver();
   const { getValuesByChain } = useChainGetters();
 
+  const { areApiReady } = useLoadingApi();
+
   useEffect(() => {
     if (!chains.length) {
       setChains([
@@ -135,6 +138,7 @@ const Sender = () => {
       <Select
         disableUnderline
         fullWidth
+        disabled={!areApiReady}
         className={classes.accountMain}
         value={value}
         renderValue={(): React.ReactNode => (

--- a/src/components/Sender.tsx
+++ b/src/components/Sender.tsx
@@ -133,8 +133,6 @@ const Sender = () => {
     return <AccountDisplay friendlyName="Select sender account" hideAddress />;
   };
 
-  console.log('areApiReady', areApiReady);
-
   return (
     <>
       <Select

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -37,7 +37,7 @@ const Transactions = ({ type, ...transactionDisplayProps }: Props) => {
 
   return (
     <>
-      {transactions.length ? (
+      {transactions?.length ? (
         transactions.map((transaction: TransactionStatusType) => {
           const onComplete = () => {
             dispatchTransaction(

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -37,7 +37,7 @@ const Transactions = ({ type, ...transactionDisplayProps }: Props) => {
 
   return (
     <>
-      {transactions?.length ? (
+      {transactions.length ? (
         transactions.map((transaction: TransactionStatusType) => {
           const onComplete = () => {
             dispatchTransaction(

--- a/src/components/Transfer.tsx
+++ b/src/components/Transfer.tsx
@@ -21,7 +21,6 @@ import { useSourceTarget } from '../contexts/SourceTargetContextProvider';
 import { useTransactionContext } from '../contexts/TransactionContext';
 import useAccounts from '../hooks/useAccounts';
 import useBalance from '../hooks/useBalance';
-import useLoadingApi from '../hooks/useLoadingApi';
 import useSendMessage from '../hooks/useSendMessage';
 import { TransactionTypes } from '../types/transactionTypes';
 import { TokenSymbol } from './TokenSymbol';
@@ -57,7 +56,6 @@ function Transfer() {
   const { sourceChainDetails, targetChainDetails } = useSourceTarget();
   const { account } = useAccounts();
 
-  const areApiReady = useLoadingApi();
   const planck = 10 ** targetChainDetails.targetApiConnection.api.registry.chainDecimals[0];
   const { estimatedFee, receiverAddress } = useTransactionContext();
   const { api, isApiReady } = sourceChainDetails.sourceApiConnection;
@@ -88,8 +86,6 @@ function Transfer() {
       actualInput &&
       setAmountNotCorrect(new BN(balance.free).sub(new BN(actualInput).add(new BN(estimatedFee))).toNumber() < 0);
   }, [actualInput, estimatedFee, balance, isApiReady]);
-
-  if (!areApiReady) return null;
 
   return (
     <>

--- a/src/components/theme.ts
+++ b/src/components/theme.ts
@@ -38,7 +38,6 @@ export const substrateGray = {
   800: '#323F47',
   900: '#202B33'
 };
-
 export const substrateGreen = {
   100: '#7E8D96',
   200: '#5CFFC8',

--- a/src/components/theme.ts
+++ b/src/components/theme.ts
@@ -39,6 +39,15 @@ export const substrateGray = {
   900: '#202B33'
 };
 
+export const substrateGreen = {
+  100: '#7E8D96',
+  200: '#5CFFC8',
+  300: '#18FFB2',
+  400: '#16DB9A',
+  500: '#11B37C',
+  600: '#1A9A6C'
+};
+
 const paletteLight: PaletteOptions = {
   type: 'light',
   common: {
@@ -65,6 +74,12 @@ const paletteLight: PaletteOptions = {
     light: red[100],
     main: '#DC2200',
     dark: red[500],
+    contrastText: 'black'
+  },
+  success: {
+    light: substrateGreen[100],
+    main: substrateGreen[400],
+    dark: substrateGreen[500],
     contrastText: 'black'
   },
   text: {

--- a/src/hooks/useApiConnection.ts
+++ b/src/hooks/useApiConnection.ts
@@ -78,7 +78,7 @@ export function useApiConnection(connectionDetails: ConnectionChainInformation):
       setConfigs(values);
     };
 
-    if (isReady && isEmpty(configs)) {
+    if (apiPromise.isReady && isEmpty(configs)) {
       getChainConfigs();
     }
   }, [apiPromise, configs, isReady]);

--- a/src/hooks/useApiConnection.ts
+++ b/src/hooks/useApiConnection.ts
@@ -70,7 +70,7 @@ export function useApiConnection(connectionDetails: ConnectionChainInformation):
         .catch((err): void => {
           logger.error(`Chain ${chainNumber}: Error registering types. Details: ${err}`);
         });
-  }, [apiPromise, chainNumber, isReady, types]);
+  }, [apiPromise, apiPromise.isReady, chainNumber, isReady, types]);
 
   useEffect(() => {
     const getChainConfigs = async () => {
@@ -81,7 +81,7 @@ export function useApiConnection(connectionDetails: ConnectionChainInformation):
     if (apiPromise.isReady && isEmpty(configs)) {
       getChainConfigs();
     }
-  }, [apiPromise, apiPromise.isReady, configs, isReady]);
+  }, [apiPromise, apiPromise.isReady, configs]);
 
   return { api: apiPromise, isApiReady: isReady, configs, polkadotjsUrl };
 }

--- a/src/hooks/useApiConnection.ts
+++ b/src/hooks/useApiConnection.ts
@@ -81,7 +81,7 @@ export function useApiConnection(connectionDetails: ConnectionChainInformation):
     if (apiPromise.isReady && isEmpty(configs)) {
       getChainConfigs();
     }
-  }, [apiPromise, configs, isReady]);
+  }, [apiPromise, apiPromise.isReady, configs, isReady]);
 
   return { api: apiPromise, isApiReady: isReady, configs, polkadotjsUrl };
 }

--- a/src/hooks/useConnections.ts
+++ b/src/hooks/useConnections.ts
@@ -31,12 +31,11 @@ export function useConnections(chainsConnections: ConnectionChainInformation[]) 
   const [apiReady, setApiReady] = useState(false);
 
   useEffect(() => {
-    if (chain1Configs && chain2Configs && apiConnection1 && apiConnection2) {
+    if (chain1Configs && chain2Configs) {
       const chainName1 = chain1Configs.chainName;
       const chainName2 = chain2Configs.chainName;
-      const apiReady = apiConnection1.isApiReady && apiConnection2.isApiReady;
-
-      if (chainName1 && chainName2 && apiReady && isEmpty(connections)) {
+      const apiReady = apiConnection1?.isApiReady && apiConnection2?.isApiReady;
+      if (chainName1 && chainName2 && isEmpty(connections)) {
         const connections = {
           [ChainDetails.SOURCE]: {
             sourceConfigs: chain1Configs,

--- a/src/hooks/useLoadingApi.ts
+++ b/src/hooks/useLoadingApi.ts
@@ -13,9 +13,6 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
-
-import { useEffect, useState } from 'react';
-
 import { useSourceTarget } from '../contexts/SourceTargetContextProvider';
 
 interface LoadingStates {
@@ -34,19 +31,9 @@ export default function useLoadingApi(): LoadingStates {
     }
   } = useSourceTarget();
 
-  const [areReady, setAreReady] = useState(false);
-  const [isSourceReady, setIsSourceReady] = useState(false);
-  const [isTargetReady, setIsTargetReady] = useState(false);
-
-  useEffect(() => {
-    isSourceApiReady && setIsSourceReady(isSourceApiReady);
-    isTargetApiReady && setIsTargetReady(isTargetApiReady);
-    setAreReady(isSourceApiReady && isTargetApiReady);
-  }, [isSourceApiReady, isTargetApiReady]);
-
   return {
-    areApiReady: areReady,
-    sourceReady: isSourceReady,
-    targetReady: isTargetReady
+    areApiReady: isSourceApiReady && false,
+    sourceReady: isSourceApiReady,
+    targetReady: isTargetApiReady
   };
 }

--- a/src/hooks/useLoadingApi.ts
+++ b/src/hooks/useLoadingApi.ts
@@ -18,7 +18,13 @@ import { useEffect, useState } from 'react';
 
 import { useSourceTarget } from '../contexts/SourceTargetContextProvider';
 
-export default function useLoadingApi(): boolean {
+interface LoadingStates {
+  areApiReady: boolean;
+  sourceReady: boolean;
+  targetReady: boolean;
+}
+
+export default function useLoadingApi(): LoadingStates {
   const {
     sourceChainDetails: {
       sourceApiConnection: { isApiReady: isSourceApiReady }
@@ -29,10 +35,18 @@ export default function useLoadingApi(): boolean {
   } = useSourceTarget();
 
   const [areReady, setAreReady] = useState(false);
+  const [isSourceReady, setIsSourceReady] = useState(false);
+  const [isTargetReady, setIsTargetReady] = useState(false);
 
   useEffect(() => {
+    isSourceApiReady && setIsSourceReady(isSourceApiReady);
+    isTargetApiReady && setIsTargetReady(isTargetApiReady);
     setAreReady(isSourceApiReady && isTargetApiReady);
   }, [isSourceApiReady, isTargetApiReady]);
 
-  return areReady;
+  return {
+    areApiReady: areReady,
+    sourceReady: isSourceReady,
+    targetReady: isTargetReady
+  };
 }

--- a/src/hooks/useSendMessage.ts
+++ b/src/hooks/useSendMessage.ts
@@ -30,6 +30,7 @@ import useTransactionPreparation from '../hooks/useTransactionPreparation';
 import { TransactionStatusEnum, TransactionTypes } from '../types/transactionTypes';
 import getSubstrateDynamicNames from '../util/getSubstrateDynamicNames';
 import logger from '../util/logger';
+import useLoadingApi from '../hooks/useLoadingApi';
 
 interface Props {
   isValidCall?: boolean;
@@ -143,16 +144,18 @@ function useSendMessage({ isRunning, isValidCall, setIsRunning, input, type, wei
     }
   };
 
+  const { areApiReady } = useLoadingApi();
+
   const isButtonDisabled = () => {
     switch (type) {
       case TransactionTypes.REMARK:
-        return isRunning || !account;
+        return isRunning || !account || !areApiReady;
         break;
       case TransactionTypes.TRANSFER:
-        return isRunning || !receiverAddress || !input || !account;
+        return isRunning || !receiverAddress || !input || !account || !areApiReady;
         break;
       case TransactionTypes.CUSTOM:
-        return isRunning || !account || !input || !weightInput || !isValidCall;
+        return isRunning || !account || !input || !weightInput || !isValidCall || !areApiReady;
         break;
       default:
         throw new Error(`Unknown type: ${type}`);

--- a/src/hooks/useTransactionNonces.ts
+++ b/src/hooks/useTransactionNonces.ts
@@ -39,7 +39,7 @@ const useTransactionNonces = ({ transaction }: Props) => {
   const { getValuesByChain } = useChainGetters();
 
   const laneId = useLaneId();
-  const areApiLoading = useLoadingApi();
+  const { areApiReady } = useLoadingApi();
   const { sourceChain, targetChain } = transaction;
   const { targetRole } = getSourceTargetRole({
     useSourceTarget,
@@ -69,7 +69,7 @@ const useTransactionNonces = ({ transaction }: Props) => {
   );
 
   useEffect(() => {
-    if (!areApiLoading || !transaction || !transaction || isTransactionCompleted(transaction)) {
+    if (!areApiReady || !transaction || !transaction || isTransactionCompleted(transaction)) {
       return;
     }
 
@@ -88,7 +88,7 @@ const useTransactionNonces = ({ transaction }: Props) => {
     getNonceOfCurrentBlock();
     getLatestReceivedNonce();
   }, [
-    areApiLoading,
+    areApiReady,
     bestBlockFinalizedOnTarget,
     transaction,
     laneId,

--- a/src/hooks/useTransactionSteps.ts
+++ b/src/hooks/useTransactionSteps.ts
@@ -42,7 +42,7 @@ const useTransactionSteps = ({ transaction, onComplete }: Props) => {
     transaction
   });
 
-  const areApiLoading = useLoadingApi();
+  const { areApiReady } = useLoadingApi();
 
   const { sourceChain, targetChain } = transaction;
   const { sourceRole, targetRole } = getSourceTargetRole({
@@ -71,7 +71,7 @@ const useTransactionSteps = ({ transaction, onComplete }: Props) => {
   }, [targetMessageDeliveryBlock, getNonceByHash, setTransactionNonceOfTargetFinalizedBlock]);
 
   useEffect(() => {
-    if (!areApiLoading || !transaction || finished) {
+    if (!areApiReady || !transaction || finished) {
       return;
     }
 
@@ -142,7 +142,7 @@ const useTransactionSteps = ({ transaction, onComplete }: Props) => {
       setFinished(true);
     }
   }, [
-    areApiLoading,
+    areApiReady,
     bestBlockFinalized,
     bestBlockFinalizedOnTarget,
     bestBridgedFinalizedBlockOnTarget,

--- a/src/hooks/useTransactionType.ts
+++ b/src/hooks/useTransactionType.ts
@@ -35,7 +35,7 @@ interface Props {
 }
 
 export default function useTransactionType({ input, type, weightInput }: Props): TransactionFunction {
-  const areApiReady = useLoadingApi();
+  const { areApiReady } = useLoadingApi();
   const {
     sourceChainDetails: {
       sourceApiConnection: { api: sourceApi }


### PR DESCRIPTION
Fixes #15 

Besides avoiding the breaking of UI when API is disconnected, enhancement has been added concerning the fact that 1 of the 2 APIs is not connected and not only both. 
Relevant Icons were added next to chain names at the sidebar.

![connected](https://user-images.githubusercontent.com/5408605/118646022-54ec4c80-b7e8-11eb-84d3-c27636088646.png)
![disconnected](https://user-images.githubusercontent.com/5408605/118646029-56b61000-b7e8-11eb-8810-8fe9b39ecb67.png)
![source only disconnected](https://user-images.githubusercontent.com/5408605/118646034-57e73d00-b7e8-11eb-82a3-6e5b9b75cb50.png)
![Screenshot from 2021-05-18 14-09-00](https://user-images.githubusercontent.com/5408605/118646092-6a617680-b7e8-11eb-9d7c-4dc868fe2f20.png)
