### PR TITLE
Move accounts to  accounts context

### DIFF
--- a/src/actions/accountActions.ts
+++ b/src/actions/accountActions.ts
@@ -14,10 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
 
+import { KeyringPair } from '@polkadot/keyring/types';
 import type { Account } from '../types/accountTypes';
 
 enum AccountActionsTypes {
-  SET_ACCOUNT = 'SET_ACCOUNT'
+  SET_ACCOUNT = 'SET_ACCOUNT',
+  SET_ACCOUNTS = 'SET_ACCOUNTS'
 }
 
 const setAccount = (account: Account) => ({
@@ -25,8 +27,14 @@ const setAccount = (account: Account) => ({
   type: AccountActionsTypes.SET_ACCOUNT
 });
 
+const setAccounts = (accounts: KeyringPair[]) => ({
+  payload: { accounts },
+  type: AccountActionsTypes.SET_ACCOUNTS
+});
+
 const AccountActionCreators = {
-  setAccount
+  setAccount,
+  setAccounts
 };
 
 export { AccountActionsTypes, AccountActionCreators };

--- a/src/contexts/AccountContextProvider.tsx
+++ b/src/contexts/AccountContextProvider.tsx
@@ -14,10 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
 
-import React, { useContext, useReducer } from 'react';
+import React, { useContext, useReducer, useEffect } from 'react';
+import { AccountActionCreators } from '../actions/accountActions';
 
 import accountReducer from '../reducers/accountReducer';
-import { AccountContextType, AccountsActionType } from '../types/accountTypes';
+import { AccountState, AccountsActionType } from '../types/accountTypes';
+import { useKeyringContext } from './KeyringContextProvider';
 
 interface AccountContextProviderProps {
   children: React.ReactElement;
@@ -27,7 +29,7 @@ export interface UpdateAccountContext {
   dispatchAccount: React.Dispatch<AccountsActionType>;
 }
 
-export const AccountContext: React.Context<AccountContextType> = React.createContext({} as AccountContextType);
+export const AccountContext: React.Context<AccountState> = React.createContext({} as AccountState);
 
 export const UpdateAccountContext: React.Context<UpdateAccountContext> = React.createContext(
   {} as UpdateAccountContext
@@ -43,10 +45,17 @@ export function useUpdateAccountContext() {
 
 export function AccountContextProvider(props: AccountContextProviderProps): React.ReactElement {
   const { children = null } = props;
-
+  const { keyringPairs, keyringPairsReady } = useKeyringContext();
   const [account, dispatchAccount] = useReducer(accountReducer, {
-    account: null
+    account: null,
+    accounts: []
   });
+
+  useEffect(() => {
+    if (keyringPairsReady && keyringPairs.length) {
+      dispatchAccount(AccountActionCreators.setAccounts(keyringPairs));
+    }
+  }, [keyringPairsReady, keyringPairs, dispatchAccount]);
 
   return (
     <AccountContext.Provider value={account}>

--- a/src/hooks/accounts/useAccounts.ts
+++ b/src/hooks/accounts/useAccounts.ts
@@ -14,14 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
 
-import { useEffect, useState, useCallback } from 'react';
+import { useCallback } from 'react';
 import type { KeyringPair } from '@polkadot/keyring/types';
 import { encodeAddress } from '@polkadot/util-crypto';
 import { AccountActionCreators } from '../../actions/accountActions';
 import { SourceTargetActionsCreators } from '../../actions/sourceTargetActions';
 import { useUpdateAccountContext } from '../../contexts/AccountContextProvider';
 import { useAccountContext } from '../../contexts/AccountContextProvider';
-import { useKeyringContext } from '../../contexts/KeyringContextProvider';
 import { useUpdateSourceTarget } from '../../contexts/SourceTargetContextProvider';
 import useDerivedAccount from './useDerivedAccount';
 import useChainGetters from '../chain/useChainGetters';
@@ -34,19 +33,11 @@ interface Accounts {
 }
 
 const useAccounts = (): Accounts => {
-  const { keyringPairs, keyringPairsReady } = useKeyringContext();
-  const [accounts, setAccounts] = useState<Array<KeyringPair> | []>([]);
   const { dispatchAccount } = useUpdateAccountContext();
   const { dispatchChangeSourceTarget } = useUpdateSourceTarget();
   const derivedAccount = useDerivedAccount();
-  const { account } = useAccountContext();
+  const { account, accounts } = useAccountContext();
   const { getSS58PrefixByChain } = useChainGetters();
-
-  useEffect(() => {
-    if (keyringPairsReady && keyringPairs.length) {
-      setAccounts(keyringPairs);
-    }
-  }, [keyringPairsReady, keyringPairs, setAccounts]);
 
   const setCurrentAccount = useCallback(
     (value: string, chain: string) => {

--- a/src/reducers/accountReducer.ts
+++ b/src/reducers/accountReducer.ts
@@ -17,7 +17,6 @@ import { AccountActionsTypes } from '../actions/accountActions';
 import type { AccountsActionType, AccountState } from '../types/accountTypes';
 
 export default function accountReducer(state: AccountState, action: AccountsActionType): AccountState {
-  console.log(action);
   switch (action.type) {
     case AccountActionsTypes.SET_ACCOUNT:
       return { ...state, account: action.payload.account };

--- a/src/reducers/accountReducer.ts
+++ b/src/reducers/accountReducer.ts
@@ -17,9 +17,12 @@ import { AccountActionsTypes } from '../actions/accountActions';
 import type { AccountsActionType, AccountState } from '../types/accountTypes';
 
 export default function accountReducer(state: AccountState, action: AccountsActionType): AccountState {
+  console.log(action);
   switch (action.type) {
     case AccountActionsTypes.SET_ACCOUNT:
       return { ...state, account: action.payload.account };
+    case AccountActionsTypes.SET_ACCOUNTS:
+      return { ...state, accounts: action.payload.accounts };
     default:
       throw new Error(`Unknown type: ${action.type}`);
   }

--- a/src/types/accountTypes.ts
+++ b/src/types/accountTypes.ts
@@ -15,21 +15,16 @@
 // along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
 
 import type { KeyringPair } from '@polkadot/keyring/types';
-
 import { AccountActionsTypes } from '../actions/accountActions';
 
 export type Account = KeyringPair | null;
 
-export interface AccountContextType {
-  account: Account;
+export interface Payload {
+  [propName: string]: any;
 }
-
-interface Payload {
-  [propName: string]: Account;
-}
-
 export interface AccountState {
   account: Account;
+  accounts: Array<KeyringPair> | [];
 }
 
 export type AccountsActionType = { type: AccountActionsTypes; payload: Payload };


### PR DESCRIPTION
Previously, the accounts read from keyring context were processed in the hook at component level. This PR moves the logic to the accounts context.
As we are going to start reading the balances from the data model level , this change is necessary.