### PR TITLE
Create API call for local transfers.

### DIFF
--- a/src/hooks/api/useApiCalls.ts
+++ b/src/hooks/api/useApiCalls.ts
@@ -109,7 +109,7 @@ const useApiCalls = (): ApiCallsContextType => {
 
           if (status.isBroadcast) {
             dispatchMessage(MessageActionsCreators.triggerInfoMessage({ message: 'Transaction was broadcasted' }));
-            // dispatchTransaction(TransactionActionCreators.reset());
+            dispatchTransaction(TransactionActionCreators.reset());
           }
 
           if (status.isInBlock) {

--- a/src/hooks/api/useApiCalls.ts
+++ b/src/hooks/api/useApiCalls.ts
@@ -70,12 +70,7 @@ const useApiCalls = (): ApiCallsContextType => {
       dispatchTransaction(TransactionActionCreators.setTransactionRunning(true));
 
       try {
-        if (!account || !receiverAddress || !transferAmount) {
-          return;
-        }
-
         const transfer = sourceApi.tx.balances.transfer(receiverAddress, transferAmount);
-
         const options: Partial<SignerOptions> = {
           nonce: -1
         };

--- a/src/hooks/api/useApiCalls.ts
+++ b/src/hooks/api/useApiCalls.ts
@@ -108,25 +108,6 @@ const useApiCalls = (): ApiCallsContextType => {
           }
 
           if (status.isInBlock) {
-            /*             sourceApi.rpc.chain
-              .getBlock(status.asInBlock)
-              .then((res) => {
-                const block = res.block.header.number.toString();
-                dispatchTransaction(
-                  TransactionActionCreators.updateTransactionStatus(
-                    {
-                      block,
-                      blockHash: status.asInBlock.toString(),
-                      status: TransactionStatusEnum.COMPLETED
-                    },
-                    id
-                  )
-                );
-              })
-              .catch((e) => {
-                logger.error(e.message);
-                throw new Error('Issue reading block information.');
-              }); */
             try {
               const res = await sourceApi.rpc.chain.getBlock(status.asInBlock);
               const block = res.block.header.number.toString();

--- a/src/hooks/api/useApiCalls.ts
+++ b/src/hooks/api/useApiCalls.ts
@@ -81,7 +81,7 @@ const useApiCalls = (): ApiCallsContextType => {
           sourceAccount = account.address;
         }
 
-        const unsub = await transfer.signAndSend(sourceAccount, { ...options }, ({ status }) => {
+        const unsub = await transfer.signAndSend(sourceAccount, { ...options }, async ({ status }) => {
           if (status.isReady) {
             dispatchTransaction(
               TransactionActionCreators.createTransactionStatus({
@@ -108,7 +108,7 @@ const useApiCalls = (): ApiCallsContextType => {
           }
 
           if (status.isInBlock) {
-            sourceApi.rpc.chain
+            /*             sourceApi.rpc.chain
               .getBlock(status.asInBlock)
               .then((res) => {
                 const block = res.block.header.number.toString();
@@ -126,7 +126,24 @@ const useApiCalls = (): ApiCallsContextType => {
               .catch((e) => {
                 logger.error(e.message);
                 throw new Error('Issue reading block information.');
-              });
+              }); */
+            try {
+              const res = await sourceApi.rpc.chain.getBlock(status.asInBlock);
+              const block = res.block.header.number.toString();
+              dispatchTransaction(
+                TransactionActionCreators.updateTransactionStatus(
+                  {
+                    block,
+                    blockHash: status.asInBlock.toString(),
+                    status: TransactionStatusEnum.COMPLETED
+                  },
+                  id
+                )
+              );
+            } catch (e) {
+              logger.error(e.message);
+              throw new Error('Issue reading block information.');
+            }
           }
 
           if (status.isFinalized) {

--- a/src/hooks/chain/useLocalTransfer.ts
+++ b/src/hooks/chain/useLocalTransfer.ts
@@ -1,0 +1,41 @@
+// Copyright 2021 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges UI.
+//
+// Parity Bridges UI is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Parity Bridges UI is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
+
+import { useCallback } from 'react';
+import { useAccountContext } from '../../contexts/AccountContextProvider';
+import { useUpdateMessageContext } from '../../contexts/MessageContext';
+import { useTransactionContext, useUpdateTransactionContext } from '../../contexts/TransactionContext';
+import useApiCalls from '../api/useApiCalls';
+
+export function useLocalTransfer() {
+  const { receiverAddress, transferAmount } = useTransactionContext();
+  const { dispatchTransaction } = useUpdateTransactionContext();
+  const { dispatchMessage } = useUpdateMessageContext();
+  const { account } = useAccountContext();
+  const { localTransfer } = useApiCalls();
+
+  const executeLocalTransfer = useCallback(() => {
+    const dispatchers = { dispatchTransaction, dispatchMessage };
+    const transferData = {
+      transferAmount,
+      receiverAddress,
+      account
+    };
+    localTransfer(dispatchers, transferData);
+  }, [account, dispatchMessage, dispatchTransaction, localTransfer, receiverAddress, transferAmount]);
+
+  return executeLocalTransfer;
+}

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -14,9 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
 
-import { Box, Typography } from '@material-ui/core';
 import React from 'react';
-
+import { Box, Typography } from '@material-ui/core';
 import { BoxSidebar, BoxUI, ButtonExt, StorageDrawer, MenuAction, NetworkSides, NetworkStats } from '../components';
 import CustomCall from '../components/CustomCall';
 import ExtensionAccountCheck from '../components/ExtensionAccountCheck';

--- a/src/types/apiCallsTypes.ts
+++ b/src/types/apiCallsTypes.ts
@@ -14,11 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
 
+import { Dispatch } from 'react';
 import type { Registry } from '@polkadot/types/types';
 import type { Bytes } from '@polkadot/types/primitive';
 
 import type { BlockHash } from '@polkadot/types/interfaces';
 import { Codec } from '@polkadot/types/types';
+import { Account } from './accountTypes';
+import BN from 'bn.js';
+import { MessagesActionType } from './messageTypes';
+import { TransactionsActionType } from './transactionTypes';
 
 export type CreateType = Registry['createType'];
 
@@ -29,7 +34,22 @@ export type StateCall = (
   at?: BlockHash | string | Uint8Array
 ) => Promise<Codec>;
 
+type TransferData = {
+  receiverAddress: string | null;
+  transferAmount: BN | null;
+  account: Account;
+};
+
+export type LocalTransfer = (
+  dispatchers: {
+    dispatchTransaction: Dispatch<TransactionsActionType>;
+    dispatchMessage: Dispatch<MessagesActionType>;
+  },
+  transfersData: TransferData
+) => void;
+
 export interface ApiCallsContextType {
   createType: CreateType;
   stateCall: StateCall;
+  localTransfer: LocalTransfer;
 }

--- a/src/types/transactionTypes.ts
+++ b/src/types/transactionTypes.ts
@@ -93,7 +93,8 @@ export type TransactionsActionType = { type: TransactionActionTypes; payload: Pa
 export enum TransactionTypes {
   CUSTOM = 'CUSTOM',
   TRANSFER = 'TRANSFER',
-  REMARK = 'REMARK'
+  REMARK = 'REMARK',
+  LOCAL_TRANSFER = 'LOCAL_TRANSFER'
 }
 
 export enum EvalMessages {


### PR DESCRIPTION
Related #213.

This PR includes the apiCall `localTransfer` implementation and it's corresponding hook `useLocalTransfer` which wraps all the necessary data for executing the local transfer.

As the idea is to submit incremental PR, the function is not being called at the moment , since we would need to have the transaction steps function to adapt the steps accordingly.
 