### PR TITLE
Moving action tab to GUI context

### DIFF
--- a/src/components/MenuAction.tsx
+++ b/src/components/MenuAction.tsx
@@ -56,7 +56,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 interface MenuActionProps {
-  actions: Array<MenuActionItemsProps>;
+  actions: MenuActionItemsProps[];
   action: TransactionTypes;
   changeMenu: (type: TransactionTypes) => void;
 }
@@ -82,7 +82,7 @@ export const MenuAction = ({ actions, changeMenu, action }: MenuActionProps) => 
   return (
     <>
       <ButtonBase className={`${classes.item} current`} onClick={handleClick}>
-        {item!.title || '-'}
+        {item?.title || '-'}
         <ArrowDropDownIcon />
       </ButtonBase>
       <Popover

--- a/src/components/MenuAction.tsx
+++ b/src/components/MenuAction.tsx
@@ -17,7 +17,9 @@
 import { ButtonBase, Popover } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
-import React, { Dispatch, SetStateAction, useEffect } from 'react';
+import React, { useEffect } from 'react';
+import { MenuActionItemsProps } from '../types/guiTypes';
+import { TransactionTypes } from '../types/transactionTypes';
 
 // As this is placed as a child in the Material UI Select component, for some reason style components classes are not working.
 // This way to inject the styles works.
@@ -53,18 +55,13 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
-interface MenuActionItemsProps {
-  idx: number;
-  title: string;
-  isEnabled: boolean;
-}
 interface MenuActionProps {
-  items: Array<MenuActionItemsProps>;
-  menuIdx: number;
-  changeMenu: Dispatch<SetStateAction<number>>;
+  actions: Array<MenuActionItemsProps>;
+  action: TransactionTypes;
+  changeMenu: (type: TransactionTypes) => void;
 }
 
-export const MenuAction = ({ items, changeMenu, menuIdx }: MenuActionProps) => {
+export const MenuAction = ({ actions, changeMenu, action }: MenuActionProps) => {
   const classes = useStyles();
   const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null);
   const [id, setId] = React.useState<string | undefined>(undefined);
@@ -80,10 +77,12 @@ export const MenuAction = ({ items, changeMenu, menuIdx }: MenuActionProps) => {
     setId(anchorEl ? 'simple-popover' : undefined);
   }, [anchorEl]);
 
+  const item = actions.find(({ type }) => type === action);
+
   return (
     <>
       <ButtonBase className={`${classes.item} current`} onClick={handleClick}>
-        {items[menuIdx]?.title || '-'}
+        {item!.title || '-'}
         <ArrowDropDownIcon />
       </ButtonBase>
       <Popover
@@ -103,13 +102,13 @@ export const MenuAction = ({ items, changeMenu, menuIdx }: MenuActionProps) => {
           className: classes.menu
         }}
       >
-        {items.map((i, n) => (
+        {actions.map((i, n) => (
           <ButtonBase
             className={`${classes.item} ${!i.isEnabled && 'disabled'}`}
             key={n}
             onClick={() => {
               setOpen(!open);
-              changeMenu(i.idx);
+              changeMenu(i.type);
             }}
           >
             {i.title}

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -25,7 +25,6 @@ import { TransactionStatusEnum, TransactionStatusType } from '../types/transacti
 import shortenItem from '../util/shortenItem';
 import TransactionStatus, { TransactionDisplayProps } from './TransactionStatus';
 import TransactionStatusMock from './TransactionStatusMock';
-import useResetTransactionState from '../hooks/transactions/useResetTransactionState';
 
 interface Props extends TransactionDisplayProps {
   type?: string;
@@ -35,7 +34,6 @@ const Transactions = ({ type, ...transactionDisplayProps }: Props) => {
   const { transactions } = useTransactionContext();
   const { dispatchTransaction } = useUpdateTransactionContext();
   const { dispatchMessage } = useUpdateMessageContext();
-  useResetTransactionState(type);
 
   return (
     <>

--- a/src/contexts/GUIContextProvider.tsx
+++ b/src/contexts/GUIContextProvider.tsx
@@ -14,14 +14,19 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
 
+import React, { useContext, useState } from 'react';
 import { createMuiTheme, ThemeProvider } from '@material-ui/core';
-import React, { useContext } from 'react';
 import useLocalStorage from '../hooks/transactions/useLocalStorage';
+import { TransactionTypes } from '../types/transactionTypes';
 import { light } from '../components';
-
+import { MenuActionItemsProps } from '../types/guiTypes';
+import useResetTransactionState from '../hooks/transactions/useResetTransactionState';
 interface DrawerContextProps {
   drawer: string;
   setDrawer: React.Dispatch<React.SetStateAction<string>>;
+  actions: MenuActionItemsProps[];
+  action: TransactionTypes;
+  setAction: (type: TransactionTypes) => void;
 }
 interface GUIContextProviderProps {
   children: React.ReactElement;
@@ -29,13 +34,33 @@ interface GUIContextProviderProps {
 
 const DrawerContext = React.createContext({} as DrawerContextProps);
 
+const actions = [
+  {
+    title: 'Transfer',
+    isEnabled: true,
+    type: TransactionTypes.TRANSFER
+  },
+  {
+    title: 'Remark',
+    isEnabled: true,
+    type: TransactionTypes.REMARK
+  },
+  {
+    title: 'Custom Call',
+    isEnabled: true,
+    type: TransactionTypes.CUSTOM
+  }
+];
+
 export function useGUIContext() {
   return useContext(DrawerContext);
 }
 
 export function GUIContextProvider({ children }: GUIContextProviderProps): React.ReactElement {
   const [drawer, setDrawer] = useLocalStorage('storageDrawer');
-  const value = { drawer, setDrawer };
+  const [action, setAction] = useState<TransactionTypes>(TransactionTypes.TRANSFER);
+  const value = { drawer, setDrawer, actions, action, setAction };
+  useResetTransactionState(action);
 
   return (
     <ThemeProvider theme={createMuiTheme(light)}>

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -15,7 +15,7 @@
 // along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
 
 import { Box, Typography } from '@material-ui/core';
-import React, { useState } from 'react';
+import React from 'react';
 
 import { BoxSidebar, BoxUI, ButtonExt, StorageDrawer, MenuAction, NetworkSides, NetworkStats } from '../components';
 import CustomCall from '../components/CustomCall';
@@ -26,40 +26,19 @@ import SnackBar from '../components/SnackBar';
 import Transfer from '../components/Transfer';
 import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
 import Transactions from '../components/Transactions';
+import { useGUIContext } from '../contexts/GUIContextProvider';
+import { TransactionTypes } from '../types/transactionTypes';
+import { MenuActionItemsProps } from '../types/guiTypes';
 
-interface MenuActionItemsProps {
-  idx: number;
-  title: string;
-  isEnabled: boolean;
-  component: React.ReactElement;
-}
-
-const MenuContents = [
-  {
-    idx: 0,
-    title: 'Transfer',
-    isEnabled: true,
-    component: <Transfer />
-  },
-  {
-    idx: 1,
-    title: 'Remark',
-    isEnabled: true,
-    component: <Remark />
-  },
-  {
-    idx: 2,
-    title: 'Custom Call',
-    isEnabled: true,
-    component: <CustomCall />
-  }
-];
+const ActionComponents = {
+  [TransactionTypes.TRANSFER]: <Transfer />,
+  [TransactionTypes.REMARK]: <Remark />,
+  [TransactionTypes.CUSTOM]: <CustomCall />
+};
 
 function Main() {
-  const [items] = useState<MenuActionItemsProps[]>(MenuContents as MenuActionItemsProps[]);
-  const [index, setIndex] = useState<number>(0);
-
-  const searchItems = (choice: number) => items.find((x) => x.idx === choice);
+  const { actions, action, setAction } = useGUIContext();
+  const searchItems = (choice: TransactionTypes) => actions.find((x: MenuActionItemsProps) => x.type === choice);
 
   return (
     <>
@@ -73,13 +52,13 @@ function Main() {
         <ButtonExt> Help & Feedback </ButtonExt>
       </BoxSidebar>
       <BoxUI>
-        <MenuAction items={items} menuIdx={index} changeMenu={setIndex} />
+        <MenuAction actions={actions} action={action} changeMenu={setAction} />
         <ExtensionAccountCheck component={<Sender />} />
         <Box marginY={2} textAlign="center" width="100%">
           <ArrowDownwardIcon fontSize="large" color="primary" />
         </Box>
-        <>{searchItems(index)?.component}</>
-        <Transactions type={searchItems(index)?.title} />
+        <>{ActionComponents[action]}</>
+        <Transactions type={searchItems(action)?.title} />
         <SnackBar />
       </BoxUI>
     </>

--- a/src/types/guiTypes.ts
+++ b/src/types/guiTypes.ts
@@ -14,20 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
 
-import { useEffect } from 'react';
-import { useUpdateTransactionContext } from '../../contexts/TransactionContext';
-import { TransactionActionCreators } from '../../actions/transactionActions';
-import usePrevious from '../react/usePrevious';
+import { TransactionTypes } from './transactionTypes';
 
-const useResetTransactionState = (action: string | number | undefined) => {
-  const { dispatchTransaction } = useUpdateTransactionContext();
-  const prevAction = usePrevious(action);
-
-  useEffect(() => {
-    if (prevAction === action) {
-      dispatchTransaction(TransactionActionCreators.reset());
-    }
-  }, [dispatchTransaction, prevAction, action]);
-};
-
-export default useResetTransactionState;
+export interface MenuActionItemsProps {
+  title: string;
+  isEnabled: boolean;
+  type: TransactionTypes;
+}


### PR DESCRIPTION
Moving the previous local state `items` &  `menuIdx` to GUI context.

The reason of this change is because when we evaluate the payload, estimatedFee we should consider some conditions met that really depends on the current action. For example, submit button should not be enabled until a receiver address is provided. In Remarks there is no receiver, so this is a conflict ( which actually is impacting the current master version ).

As all these conditions are being evaluated with reducers, having the current action in a local state makes things harder to handle ( we could set the action type as parameter on each reducer action, but is much easier to rely on the context)