### PR TITLE
Refactoring generic call

### DIFF
--- a/src/util/apiUtlis.ts
+++ b/src/util/apiUtlis.ts
@@ -35,11 +35,12 @@ export const genericCall = async ({ call, emptyData = null, dispatch }: Dispatch
     executeDispatch(null, emptyData, true);
     data = await call();
     executeDispatch(null, data, false);
+    return { data, error };
   } catch (e) {
     error = e.message;
     executeDispatch(error, emptyData, false);
+    return { data: emptyData, error };
   }
-  return { data, error };
 };
 
 export default { genericCall };

--- a/src/util/apiUtlis.ts
+++ b/src/util/apiUtlis.ts
@@ -21,7 +21,7 @@ interface Result<T> {
   data: T | null;
 }
 interface DispatchGenericCallInput<T> {
-  call: (...args: any[]) => T;
+  call: (...args: any[]) => Promise<T>;
   dispatch?: (error: string | null, data: T | null, loading: boolean) => void;
   emptyData?: T | null;
 }
@@ -33,20 +33,19 @@ export const genericCall = async <T>({
 }: DispatchGenericCallInput<T>): Promise<Result<T>> => {
   let data = emptyData;
   let error = null;
-  const executeDispatch = (error: string | null, data: any, loading: boolean) =>
+  const executeDispatch = (error: string | null, data: T | null, loading: boolean) =>
     dispatch && dispatch(error, data, loading);
 
   try {
     executeDispatch(null, emptyData, true);
     data = await call();
-    executeDispatch(null, data, false);
-    return { data, error };
   } catch (e) {
     error = e.message;
     logger.error(error);
-    executeDispatch(error, emptyData, false);
-    return { data: emptyData, error };
+  } finally {
+    executeDispatch(error, data, false);
   }
+  return { data, error };
 };
 
 export default { genericCall };

--- a/src/util/apiUtlis.ts
+++ b/src/util/apiUtlis.ts
@@ -26,7 +26,7 @@ interface Result {
 }
 
 export const genericCall = async ({ call, emptyData = null, dispatch }: DispatchGenericCallInput): Promise<Result> => {
-  let data = null;
+  let data = emptyData;
   let error = null;
   const executeDispatch = (error: string | null, data: any, loading: boolean) =>
     dispatch && dispatch(error, data, loading);

--- a/src/util/apiUtlis.ts
+++ b/src/util/apiUtlis.ts
@@ -14,18 +14,23 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
 
-interface DispatchGenericCallInput {
-  call: Function;
-  dispatch?: (error: string | null, data: any, loading: boolean) => void;
-  emptyData?: unknown;
-}
+import logger from '../util/logger';
 
-interface Result {
+interface Result<T> {
   error: string | null;
-  data: unknown | null;
+  data: T | null;
+}
+interface DispatchGenericCallInput<T> {
+  call: (...args: any[]) => T;
+  dispatch?: (error: string | null, data: T | null, loading: boolean) => void;
+  emptyData?: T | null;
 }
 
-export const genericCall = async ({ call, emptyData = null, dispatch }: DispatchGenericCallInput): Promise<Result> => {
+export const genericCall = async <T>({
+  call,
+  emptyData = null,
+  dispatch
+}: DispatchGenericCallInput<T>): Promise<Result<T>> => {
   let data = emptyData;
   let error = null;
   const executeDispatch = (error: string | null, data: any, loading: boolean) =>
@@ -38,6 +43,7 @@ export const genericCall = async ({ call, emptyData = null, dispatch }: Dispatch
     return { data, error };
   } catch (e) {
     error = e.message;
+    logger.error(error);
     executeDispatch(error, emptyData, false);
     return { data: emptyData, error };
   }

--- a/src/util/apiUtlis.ts
+++ b/src/util/apiUtlis.ts
@@ -1,0 +1,45 @@
+// Copyright 2021 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges UI.
+//
+// Parity Bridges UI is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Parity Bridges UI is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
+
+interface DispatchGenericCallInput {
+  call: Function;
+  dispatch?: (error: string | null, data: any, loading: boolean) => void;
+  emptyData?: unknown;
+}
+
+interface Result {
+  error: string | null;
+  data: unknown | null;
+}
+
+export const genericCall = async ({ call, emptyData = null, dispatch }: DispatchGenericCallInput): Promise<Result> => {
+  let data = null;
+  let error = null;
+  const executeDispatch = (error: string | null, data: any, loading: boolean) =>
+    dispatch && dispatch(error, data, loading);
+
+  try {
+    executeDispatch(null, emptyData, true);
+    data = await call();
+    executeDispatch(null, data, false);
+  } catch (e) {
+    error = e;
+    executeDispatch(e, emptyData, false);
+  }
+  return { data, error };
+};
+
+export default { genericCall };

--- a/src/util/apiUtlis.ts
+++ b/src/util/apiUtlis.ts
@@ -36,8 +36,8 @@ export const genericCall = async ({ call, emptyData = null, dispatch }: Dispatch
     data = await call();
     executeDispatch(null, data, false);
   } catch (e) {
-    error = e;
-    executeDispatch(e, emptyData, false);
+    error = e.message;
+    executeDispatch(error, emptyData, false);
   }
   return { data, error };
 };

--- a/src/util/tests/apiUtils.test.ts
+++ b/src/util/tests/apiUtils.test.ts
@@ -46,7 +46,7 @@ describe('genericCall', () => {
       it('should return expected data with no errors', async () => {
         const { data, error } = await genericCall({ call: successCall, emptyData });
         expect(error).toBeNull();
-        expect(data).toEqual(testData);
+        expect(data).toEqual({ testData });
       });
 
       it('should fail and null data and error mesage', async () => {
@@ -68,7 +68,7 @@ describe('genericCall', () => {
       it('should call dispatch according to successful execution with no empty data provided', async () => {
         await genericCall({ call: successCall, dispatch });
         expect(dispatch.mock.calls[0]).toEqual([null, null, true]);
-        expect(dispatch.mock.calls[1]).toEqual([null, testData, false]);
+        expect(dispatch.mock.calls[1]).toEqual([null, { testData }, false]);
       });
       it('should call dispatch according to a failed execution with no empty data provided', async () => {
         await genericCall({ call: failedCall, dispatch });
@@ -81,7 +81,7 @@ describe('genericCall', () => {
       it('should call dispatch according to successful execution with no empty data provided', async () => {
         await genericCall({ call: successCall, dispatch, emptyData });
         expect(dispatch.mock.calls[0]).toEqual([null, emptyData, true]);
-        expect(dispatch.mock.calls[1]).toEqual([null, testData, false]);
+        expect(dispatch.mock.calls[1]).toEqual([null, { testData }, false]);
       });
       it('should call dispatch according to a failed execution with no empty data provided', async () => {
         await genericCall({ call: failedCall, dispatch, emptyData });

--- a/src/util/tests/apiUtils.test.ts
+++ b/src/util/tests/apiUtils.test.ts
@@ -1,0 +1,97 @@
+// Copyright 2021 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges UI.
+//
+// Parity Bridges UI is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Parity Bridges UI is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
+
+import { genericCall } from '../apiUtlis';
+
+describe('genericCall', () => {
+  let successCall: jest.Mock;
+  let failedCall: jest.Mock;
+  const testData = 'this is a data message';
+  const message = 'this is an error message';
+
+  beforeEach(() => {
+    successCall = jest.fn().mockResolvedValue(testData);
+    failedCall = jest.fn().mockRejectedValue({ message });
+  });
+
+  describe('returned values', () => {
+    describe('without emptyData', () => {
+      it('should return expected data with no errors', async () => {
+        const testData = 'this is a data message';
+        const { data, error } = await genericCall({ call: successCall });
+        expect(error).toBeNull();
+        expect(data).toEqual(testData);
+      });
+
+      it('should fail and null data and error mesage', async () => {
+        const { data, error } = await genericCall({ call: failedCall });
+        expect(data).toBeNull();
+        expect(error).toEqual(message);
+      });
+    });
+
+    describe('with emptyData', () => {
+      const emptyData = { data: 'empty' };
+      it('should return expected data with no errors', async () => {
+        const testData = 'this is a data message';
+        const { data, error } = await genericCall({ call: successCall, emptyData });
+        expect(error).toBeNull();
+        expect(data).toEqual(testData);
+      });
+
+      it('should fail and null data and error mesage', async () => {
+        const { data, error } = await genericCall({ call: failedCall, emptyData });
+        expect(data).toEqual(emptyData);
+        expect(error).toEqual(message);
+      });
+    });
+  });
+
+  describe('dispatchers', () => {
+    let dispatch: jest.Mock;
+
+    beforeEach(() => {
+      dispatch = jest.fn();
+    });
+
+    describe('without emptyData', () => {
+      it('should call dispatch according to successful execution with no empty data provided', async () => {
+        await genericCall({ call: successCall, dispatch });
+        expect(dispatch.mock.calls[0]).toEqual([null, null, true]);
+        expect(dispatch.mock.calls[1]).toEqual([null, testData, false]);
+      });
+      it('should call dispatch according to a failed execution with no empty data provided', async () => {
+        await genericCall({ call: failedCall, dispatch });
+        expect(dispatch.mock.calls[0]).toEqual([null, null, true]);
+        expect(dispatch.mock.calls[1]).toEqual([message, null, false]);
+      });
+    });
+
+    describe('with emptyData', () => {
+      const emptyData = { data: 'empty' };
+      it('should call dispatch according to successful execution with no empty data provided', async () => {
+        await genericCall({ call: successCall, dispatch, emptyData });
+        expect(dispatch.mock.calls[0]).toEqual([null, emptyData, true]);
+        expect(dispatch.mock.calls[1]).toEqual([null, testData, false]);
+      });
+      it('should call dispatch according to a failed execution with no empty data provided', async () => {
+        await genericCall({ call: failedCall, dispatch, emptyData });
+        expect(dispatch.mock.calls[0]).toEqual([null, emptyData, true]);
+        expect(dispatch.mock.calls[1]).toEqual([message, emptyData, false]);
+      });
+    });
+  });
+});

--- a/src/util/tests/apiUtils.test.ts
+++ b/src/util/tests/apiUtils.test.ts
@@ -17,23 +17,22 @@
 import { genericCall } from '../apiUtlis';
 
 describe('genericCall', () => {
-  let successCall: jest.Mock;
+  let successCall: jest.Mock<any[], any>;
   let failedCall: jest.Mock;
   const testData = 'this is a data message';
   const message = 'this is an error message';
-
+  const emptyData = { testData: 'empty' };
   beforeEach(() => {
-    successCall = jest.fn().mockResolvedValue(testData);
+    successCall = jest.fn().mockResolvedValue({ testData });
     failedCall = jest.fn().mockRejectedValue({ message });
   });
 
   describe('returned values', () => {
     describe('without emptyData', () => {
       it('should return expected data with no errors', async () => {
-        const testData = 'this is a data message';
         const { data, error } = await genericCall({ call: successCall });
         expect(error).toBeNull();
-        expect(data).toEqual(testData);
+        expect(data).toEqual({ testData });
       });
 
       it('should fail and null data and error mesage', async () => {
@@ -44,9 +43,7 @@ describe('genericCall', () => {
     });
 
     describe('with emptyData', () => {
-      const emptyData = { data: 'empty' };
       it('should return expected data with no errors', async () => {
-        const testData = 'this is a data message';
         const { data, error } = await genericCall({ call: successCall, emptyData });
         expect(error).toBeNull();
         expect(data).toEqual(testData);
@@ -81,7 +78,6 @@ describe('genericCall', () => {
     });
 
     describe('with emptyData', () => {
-      const emptyData = { data: 'empty' };
       it('should call dispatch according to successful execution with no empty data provided', async () => {
         await genericCall({ call: successCall, dispatch, emptyData });
         expect(dispatch.mock.calls[0]).toEqual([null, emptyData, true]);


### PR DESCRIPTION
Based on previous discussions and a tendency of get rid of the hooks abuse, there is a need to simplify the generic call process that handles async calls properly covering all the cases and in case a dispatcher is provided, dispatches the corresponding actions under the `loading`,`error` & `data` values. 

Also i have added the `initalData` in case we need to set any specific value than `null`