### PR TITLE
Changing the process to read the chain name from rpc.system.chain

### DIFF
--- a/src/util/getConfigs.ts
+++ b/src/util/getConfigs.ts
@@ -20,7 +20,7 @@ import { Configs } from '../types/sourceTargetTypes';
 export const getConfigs = async (apiPromise: ApiPromise): Promise<Configs> => {
   const properties = apiPromise.registry.getChainProperties();
   const { ss58Format } = properties!;
-  const systemChain = await apiPromise.rpc.system.name();
+  const systemChain = await apiPromise.rpc.system.chain();
   const chainName = systemChain.split(' ')[0];
   const prop = await apiPromise.rpc.system.properties();
   const bridgeIds = prop.get('bridgeIds');


### PR DESCRIPTION
This simple PR can be merged once the PR on the bridges common repository gets [1079](https://github.com/paritytech/parity-bridges-common/pull/1079) merged.