### PR TITLE
Fix logic for letting the user execute the transaction based on available funds.

### DIFF
--- a/src/actions/transactionActions.ts
+++ b/src/actions/transactionActions.ts
@@ -45,6 +45,7 @@ enum TransactionActionTypes {
   UPDATE_TRANSACTIONS_STATUS = 'UPDATE_TRANSACTIONS_STATUS',
   SET_BATCH_PAYLOAD_ESTIMATED_FEE = 'SET_BATCH_PAYLOAD_ESTIMATED_FEE',
   UPDATE_SENDER_BALANCES = 'UPDATE_SENDER_BALANCES',
+  SET_TRANSFER_TYPE = 'SET_TRANSFER_TYPE',
   RESET = 'RESET'
 }
 
@@ -161,6 +162,11 @@ const updateSenderBalances = ({ senderAccountBalance, senderCompanionAccountBala
   type: TransactionActionTypes.UPDATE_SENDER_BALANCES
 });
 
+const setTransferType = (transferType: TransactionTypes) => ({
+  payload: { transferType },
+  type: TransactionActionTypes.SET_TRANSFER_TYPE
+});
+
 const TransactionActionCreators = {
   setSender,
   setAction,
@@ -177,6 +183,7 @@ const TransactionActionCreators = {
   updateTransactionsStatus,
   setBatchedEvaluationPayloadEstimatedFee,
   updateSenderBalances,
+  setTransferType,
   reset
 };
 

--- a/src/actions/transactionActions.ts
+++ b/src/actions/transactionActions.ts
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
 
+import { BalanceState } from '../types/accountTypes';
 import { CreateType } from '../types/apiCallsTypes';
 import { SourceTargetState } from '../types/sourceTargetTypes';
 
@@ -32,7 +33,8 @@ enum TransactionActionTypes {
   SET_RECEIVER = 'SET_RECEIVER',
   SET_RECEIVER_ADDRESS = 'SET_RECEIVER_ADDRESS',
   SET_RECEIVER_VALIDATION = 'SET_RECEIVER_VALIDATION',
-  SET_SENDER_AND_ACTION = 'SET_SENDER_AND_ACTION',
+  SET_SENDER = 'SET_SENDER',
+  SET_ACTION = 'SET_ACTION',
   SET_PAYLOAD_ESTIMATED_FEE = 'SET_PAYLOAD_ESTIMATED_FEE',
   CREATE_TRANSACTION_STATUS = 'CREATE_TRANSACTION_STATUS',
   UPDATE_CURRENT_TRANSACTION_STATUS = 'UPDATE_CURRENT_TRANSACTION_STATUS',
@@ -42,6 +44,7 @@ enum TransactionActionTypes {
   SET_WEIGHT_INPUT = 'SET_WEIGHT_INPUT',
   UPDATE_TRANSACTIONS_STATUS = 'UPDATE_TRANSACTIONS_STATUS',
   SET_BATCH_PAYLOAD_ESTIMATED_FEE = 'SET_BATCH_PAYLOAD_ESTIMATED_FEE',
+  UPDATE_SENDER_BALANCES = 'UPDATE_SENDER_BALANCES',
   RESET = 'RESET'
 }
 
@@ -58,7 +61,9 @@ const setPayloadEstimatedFee = (
   payloadEstimatedFeeLoading: boolean,
   sourceTargetDetails: SourceTargetState,
   createType: CreateType,
-  isBridged: boolean
+  isBridged: boolean,
+  senderAccountBalance: BalanceState | null,
+  senderCompanionAccountBalance: BalanceState | null
 ) => ({
   payload: {
     payloadEstimatedFee,
@@ -66,7 +71,9 @@ const setPayloadEstimatedFee = (
     payloadEstimatedFeeLoading,
     sourceTargetDetails,
     createType,
-    isBridged
+    isBridged,
+    senderAccountBalance,
+    senderCompanionAccountBalance
   },
   type: TransactionActionTypes.SET_PAYLOAD_ESTIMATED_FEE
 });
@@ -114,13 +121,14 @@ const setTransactionRunning = (transactionRunning: boolean) => ({
   type: TransactionActionTypes.SET_TRANSACTION_RUNNING
 });
 
-type SenderAndActionInput = {
-  senderAccount: string | null;
-  action: TransactionTypes;
-};
-const setSenderAndAction = ({ senderAccount, action }: SenderAndActionInput) => ({
-  payload: { senderAccount, action },
-  type: TransactionActionTypes.SET_SENDER_AND_ACTION
+const setAction = (action: TransactionTypes) => ({
+  payload: { action },
+  type: TransactionActionTypes.SET_ACTION
+});
+
+const setSender = (senderAccount: string | null) => ({
+  payload: { senderAccount },
+  type: TransactionActionTypes.SET_SENDER
 });
 
 const setRemarkInput = (remarkInput: string | null) => ({
@@ -143,8 +151,19 @@ const setBatchedEvaluationPayloadEstimatedFee = (batchedTransactionState: Transa
   type: TransactionActionTypes.SET_BATCH_PAYLOAD_ESTIMATED_FEE
 });
 
+type UpdateSenderBalances = {
+  senderAccountBalance: BalanceState | null;
+  senderCompanionAccountBalance: BalanceState | null;
+};
+
+const updateSenderBalances = ({ senderAccountBalance, senderCompanionAccountBalance }: UpdateSenderBalances) => ({
+  payload: { senderAccountBalance, senderCompanionAccountBalance },
+  type: TransactionActionTypes.UPDATE_SENDER_BALANCES
+});
+
 const TransactionActionCreators = {
-  setSenderAndAction,
+  setSender,
+  setAction,
   setReceiverAddress,
   setReceiver,
   setTransferAmount,
@@ -157,6 +176,7 @@ const TransactionActionCreators = {
   updateTransactionStatus,
   updateTransactionsStatus,
   setBatchedEvaluationPayloadEstimatedFee,
+  updateSenderBalances,
   reset
 };
 

--- a/src/components/EstimatedFee.tsx
+++ b/src/components/EstimatedFee.tsx
@@ -20,7 +20,7 @@ import React from 'react';
 import { useSourceTarget } from '../contexts/SourceTargetContextProvider';
 import { useTransactionContext } from '../contexts/TransactionContext';
 import { transformToBaseUnit } from '../util/evalUnits';
-import { TransactionTypes } from '../types/transactionTypes';
+import { Alert } from '.';
 
 const useStyles = makeStyles(() => ({
   container: {
@@ -31,7 +31,12 @@ const useStyles = makeStyles(() => ({
 export const EstimatedFee = (): React.ReactElement => {
   const classes = useStyles();
   const { sourceChainDetails } = useSourceTarget();
-  const { estimatedFee, payloadEstimatedFeeLoading, transactionRunning } = useTransactionContext();
+  const {
+    estimatedFee,
+    payloadEstimatedFeeLoading,
+    transactionRunning,
+    evaluateTransactionStatusError
+  } = useTransactionContext();
   const srcChainDecimals = sourceChainDetails.apiConnection.api.registry.chainDecimals[0];
   const { chainTokens } = sourceChainDetails.apiConnection.api.registry;
 
@@ -43,7 +48,9 @@ export const EstimatedFee = (): React.ReactElement => {
 
   const feeLabel = `Estimated ${sourceChainDetails.chain} fee`;
 
-  return (
+  return evaluateTransactionStatusError ? (
+    <Alert severity="error">{evaluateTransactionStatusError}</Alert>
+  ) : (
     <div className={classes.container}>
       <Typography variant="body1" color="secondary">
         {payloadEstimatedFeeLoading && !transactionRunning
@@ -55,19 +62,3 @@ export const EstimatedFee = (): React.ReactElement => {
     </div>
   );
 };
-
-/* export const EstimatedFee = (): React.ReactElement => {
-  const { action } = useTransactionContext();
-
-  useEffect((): void => {
-    estimatedFee && setEnoughForPayFee(new BN(balance.free).sub(new BN(estimatedFee)).isNeg());
-    senderCompanionAccountBalance &&
-      transferAmount &&
-      setEnoughForTransfer(new BN(senderCompanionAccountBalance.free).sub(transferAmount).isNeg());
-  }, [transferAmount, estimatedFee, balance, senderCompanionAccountBalance]);
-
-  if (action === TransactionTypes.TRANSFER) {
-
-  }
-};
- */

--- a/src/components/EstimatedFee.tsx
+++ b/src/components/EstimatedFee.tsx
@@ -20,6 +20,7 @@ import React from 'react';
 import { useSourceTarget } from '../contexts/SourceTargetContextProvider';
 import { useTransactionContext } from '../contexts/TransactionContext';
 import { transformToBaseUnit } from '../util/evalUnits';
+import { TransactionTypes } from '../types/transactionTypes';
 
 const useStyles = makeStyles(() => ({
   container: {
@@ -54,3 +55,19 @@ export const EstimatedFee = (): React.ReactElement => {
     </div>
   );
 };
+
+/* export const EstimatedFee = (): React.ReactElement => {
+  const { action } = useTransactionContext();
+
+  useEffect((): void => {
+    estimatedFee && setEnoughForPayFee(new BN(balance.free).sub(new BN(estimatedFee)).isNeg());
+    senderCompanionAccountBalance &&
+      transferAmount &&
+      setEnoughForTransfer(new BN(senderCompanionAccountBalance.free).sub(transferAmount).isNeg());
+  }, [transferAmount, estimatedFee, balance, senderCompanionAccountBalance]);
+
+  if (action === TransactionTypes.TRANSFER) {
+
+  }
+};
+ */

--- a/src/components/Transfer.tsx
+++ b/src/components/Transfer.tsx
@@ -14,21 +14,18 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useEffect, useCallback } from 'react';
 import { Box, makeStyles } from '@material-ui/core';
 import { useSourceTarget } from '../contexts/SourceTargetContextProvider';
 import { useTransactionContext } from '../contexts/TransactionContext';
-import { useAccountContext } from '../contexts/AccountContextProvider';
 import { TransactionActionCreators } from '../actions/transactionActions';
 import { useUpdateTransactionContext } from '../contexts/TransactionContext';
-import useBalance from '../hooks/subscriptions/useBalance';
 import useSendMessage from '../hooks/chain/useSendMessage';
 import { TransactionTypes } from '../types/transactionTypes';
 import { TokenSymbol } from './TokenSymbol';
 import Receiver from './Receiver';
-import { Alert, ButtonSubmit } from '../components';
+import { ButtonSubmit } from '../components';
 import { EstimatedFee } from '../components/EstimatedFee';
-import BN from 'bn.js';
 import { DebouncedTextField } from './DebouncedTextField';
 import { useInternalTransfer } from '../hooks/chain/useInternalTransfer';
 import { useGUIContext } from '../contexts/GUIContextProvider';
@@ -55,21 +52,15 @@ const useStyles = makeStyles((theme) => ({
 function Transfer() {
   const { dispatchTransaction } = useUpdateTransactionContext();
   const classes = useStyles();
-  const [enoughForTransfer, setEnoughForTransfer] = useState<boolean>(false);
-  const [enoughForPayFee, setEnoughForPayFee] = useState<boolean>(false);
   const { sourceChainDetails, targetChainDetails } = useSourceTarget();
   const { isBridged } = useGUIContext();
-  const { account, senderCompanionAccountBalance } = useAccountContext();
   const {
-    estimatedFee,
     transferAmount,
     transferAmountError,
     transactionRunning,
-    transactionReadyToExecute,
-    evaluateTransactionStatusError
+    transactionReadyToExecute
   } = useTransactionContext();
   const { api } = sourceChainDetails.apiConnection;
-  const balance = useBalance(api, account?.address || '');
   const executeInternalTransfer = useInternalTransfer();
 
   const dispatchCallback = useCallback(
@@ -122,17 +113,10 @@ function Transfer() {
         />
       </Box>
       <Receiver />
-      <ButtonSubmit
-        disabled={!transactionReadyToExecute || enoughForTransfer || enoughForPayFee}
-        onClick={sendTransaction}
-      >
+      <ButtonSubmit disabled={!transactionReadyToExecute} onClick={sendTransaction}>
         {buttonLabel}
       </ButtonSubmit>
-      {evaluateTransactionStatusError ? (
-        <Alert severity="error">{evaluateTransactionStatusError}</Alert>
-      ) : (
-        <EstimatedFee />
-      )}
+      <EstimatedFee />
     </>
   );
 }

--- a/src/hooks/context/useSendersBalancesContext.ts
+++ b/src/hooks/context/useSendersBalancesContext.ts
@@ -84,5 +84,5 @@ export default function useSendersBalancesContext(
     if (blocksReached) {
       updateAccounts();
     }
-  }, [blocksReached, updateAccounts, timerId, accountState.account]);
+  }, [blocksReached, updateAccounts, timerId]);
 }

--- a/src/hooks/context/useSendersBalancesContext.ts
+++ b/src/hooks/context/useSendersBalancesContext.ts
@@ -84,5 +84,5 @@ export default function useSendersBalancesContext(
     if (blocksReached) {
       updateAccounts();
     }
-  }, [blocksReached, updateAccounts, timerId]);
+  }, [blocksReached, updateAccounts, timerId, accountState.account]);
 }

--- a/src/hooks/transactions/useEstimatedFeePayload.ts
+++ b/src/hooks/transactions/useEstimatedFeePayload.ts
@@ -47,7 +47,7 @@ export const useEstimatedFeePayload = (
       chain: targetChain
     }
   } = sourceTargetDetails;
-  const { account } = useAccountContext();
+  const { account, senderAccountBalance, senderCompanionAccountBalance } = useAccountContext();
   const { action, isBridged } = useGUIContext();
   const { estimatedFeeMethodName } = getSubstrateDynamicNames(targetChain);
   const previousPayloadEstimatedFeeLoading = usePrevious(transactionState.payloadEstimatedFeeLoading);
@@ -61,10 +61,19 @@ export const useEstimatedFeePayload = (
           loading,
           sourceTargetDetails,
           createType,
-          isBridged
+          isBridged,
+          senderAccountBalance,
+          senderCompanionAccountBalance
         )
       ),
-    [createType, dispatchTransaction, isBridged, sourceTargetDetails]
+    [
+      createType,
+      dispatchTransaction,
+      isBridged,
+      senderAccountBalance,
+      senderCompanionAccountBalance,
+      sourceTargetDetails
+    ]
   );
 
   const calculateFeeAndPayload = useCallback(
@@ -126,7 +135,15 @@ export const useEstimatedFeePayload = (
 
   useEffect(() => {
     const { batchedTransactionState, payloadEstimatedFeeLoading } = transactionState;
-    if (previousPayloadEstimatedFeeLoading && !payloadEstimatedFeeLoading && batchedTransactionState) {
+
+    if (
+      previousPayloadEstimatedFeeLoading &&
+      !payloadEstimatedFeeLoading &&
+      batchedTransactionState &&
+      senderAccountBalance &&
+      senderCompanionAccountBalance
+    ) {
+      console.log('CALLING USEESTI', senderAccountBalance, senderCompanionAccountBalance);
       genericCall({
         call: () => calculateFeeAndPayload(batchedTransactionState),
         dispatch,
@@ -140,6 +157,8 @@ export const useEstimatedFeePayload = (
     dispatch,
     dispatchTransaction,
     previousPayloadEstimatedFeeLoading,
+    senderAccountBalance,
+    senderCompanionAccountBalance,
     transactionState
   ]);
 };

--- a/src/hooks/transactions/useEstimatedFeePayload.ts
+++ b/src/hooks/transactions/useEstimatedFeePayload.ts
@@ -41,7 +41,10 @@ export const useEstimatedFeePayload = (
   const laneId = useLaneId();
   const sourceTargetDetails = useSourceTarget();
   const {
-    sourceChainDetails: { chain: sourceChain },
+    sourceChainDetails: {
+      chain: sourceChain,
+      apiConnection: { api: sourceApi }
+    },
     targetChainDetails: {
       apiConnection: { api: targetApi },
       chain: targetChain
@@ -82,6 +85,7 @@ export const useEstimatedFeePayload = (
         action,
         account,
         targetApi,
+        sourceApi,
         transactionState: currentTransactionState
       });
 
@@ -112,7 +116,7 @@ export const useEstimatedFeePayload = (
       const estimatedFee = estimatedFeeType.toString();
       return { estimatedFee, payload };
     },
-    [account, action, createType, estimatedFeeMethodName, laneId, sourceChain, stateCall, targetApi]
+    [account, action, createType, estimatedFeeMethodName, laneId, sourceApi, sourceChain, stateCall, targetApi]
   );
 
   useEffect(() => {
@@ -143,7 +147,6 @@ export const useEstimatedFeePayload = (
       senderAccountBalance &&
       senderCompanionAccountBalance
     ) {
-      console.log('CALLING USEESTI', senderAccountBalance, senderCompanionAccountBalance);
       genericCall({
         call: () => calculateFeeAndPayload(batchedTransactionState),
         dispatch,

--- a/src/hooks/transactions/useSenderBalanceUpdates.ts
+++ b/src/hooks/transactions/useSenderBalanceUpdates.ts
@@ -1,0 +1,59 @@
+// Copyright 2021 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges UI.
+//
+// Parity Bridges UI is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Parity Bridges UI is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
+
+import { Dispatch, useEffect } from 'react';
+import isEqual from 'lodash/isEqual';
+import { TransactionActionCreators } from '../../actions/transactionActions';
+
+import { TransactionsActionType } from '../../types/transactionTypes';
+import usePrevious from '../react/usePrevious';
+import { BalanceState } from '../../types/accountTypes';
+
+const useSenderBalanceUpdates = (
+  senderAccountBalance: BalanceState | null,
+  senderCompanionAccountBalance: BalanceState | null,
+  dispatchTransaction: Dispatch<TransactionsActionType>
+) => {
+  const prevSenderAccountBalance = usePrevious(senderAccountBalance);
+  const prevSenderCompanionAccountBalance = usePrevious(senderCompanionAccountBalance);
+
+  useEffect((): void => {
+    console.log(
+      '!isEqual(prevSenderAccountBalance, senderAccountBalance)',
+      !isEqual(prevSenderAccountBalance, senderAccountBalance)
+    );
+    if (
+      (senderAccountBalance &&
+        senderCompanionAccountBalance &&
+        !isEqual(prevSenderAccountBalance, senderAccountBalance)) ||
+      !isEqual(prevSenderCompanionAccountBalance, senderCompanionAccountBalance)
+    )
+      dispatchTransaction(
+        TransactionActionCreators.updateSenderBalances({
+          senderAccountBalance,
+          senderCompanionAccountBalance
+        })
+      );
+  }, [
+    dispatchTransaction,
+    prevSenderAccountBalance,
+    prevSenderCompanionAccountBalance,
+    senderAccountBalance,
+    senderCompanionAccountBalance
+  ]);
+};
+
+export default useSenderBalanceUpdates;

--- a/src/hooks/transactions/useSenderBalanceUpdates.ts
+++ b/src/hooks/transactions/useSenderBalanceUpdates.ts
@@ -31,10 +31,6 @@ const useSenderBalanceUpdates = (
   const prevSenderCompanionAccountBalance = usePrevious(senderCompanionAccountBalance);
 
   useEffect((): void => {
-    console.log(
-      '!isEqual(prevSenderAccountBalance, senderAccountBalance)',
-      !isEqual(prevSenderAccountBalance, senderAccountBalance)
-    );
     if (
       (senderAccountBalance &&
         senderCompanionAccountBalance &&

--- a/src/reducers/accountReducer.ts
+++ b/src/reducers/accountReducer.ts
@@ -43,7 +43,7 @@ export default function accountReducer(state: AccountState, action: AccountsActi
 
       const companionAccount = getDeriveAccount(toDerive);
 
-      return { ...state, account, companionAccount };
+      return { ...state, account, companionAccount, senderAccountBalance: null, senderCompanionAccountBalance: null };
     }
     case AccountActionsTypes.SET_SENDER_BALANCES:
       return {

--- a/src/reducers/transactionReducer.ts
+++ b/src/reducers/transactionReducer.ts
@@ -61,8 +61,8 @@ export default function transactionReducer(state: TransactionState, action: Tran
       let payloadHex = null;
       let transactionDisplayPayload = null;
 
-      if (senderAccount) {
-        if (payload && isBridged) {
+      if (senderAccount && payload) {
+        if (isBridged) {
           const updated = getTransactionDisplayPayload({
             payload,
             account: senderAccount,
@@ -76,7 +76,8 @@ export default function transactionReducer(state: TransactionState, action: Tran
           transactionDisplayPayload = {
             sourceAccount: senderAccount,
             transferAmount: transferAmount.toNumber(),
-            receiverAddress: receiverAddress
+            receiverAddress: receiverAddress,
+            weight: payload.weight
           };
         }
       }
@@ -87,7 +88,6 @@ export default function transactionReducer(state: TransactionState, action: Tran
         payloadEstimatedFeeError,
         payloadEstimatedFeeLoading,
         payload: payloadEstimatedFeeError ? null : payload,
-
         transactionReadyToExecute: readyToExecute,
         shouldEvaluatePayloadEstimatedFee: false,
         payloadHex,

--- a/src/reducers/transactionReducer.ts
+++ b/src/reducers/transactionReducer.ts
@@ -30,7 +30,6 @@ import { getTransactionDisplayPayload } from '../util/transactions';
 import { isHex } from '@polkadot/util';
 
 export default function transactionReducer(state: TransactionState, action: TransactionsActionType): TransactionState {
-  console.log(action);
   const transactionReadyToExecute = isReadyToExecute({ ...state, ...action.payload });
   switch (action.type) {
     case TransactionActionTypes.SET_PAYLOAD_ESTIMATED_FEE: {
@@ -51,7 +50,8 @@ export default function transactionReducer(state: TransactionState, action: Tran
         transferAmount,
         senderCompanionAccountBalance,
         senderAccountBalance,
-        estimatedFee
+        estimatedFee,
+        action: state.action
       });
 
       const readyToExecute = payloadEstimatedFeeLoading
@@ -260,14 +260,7 @@ export default function transactionReducer(state: TransactionState, action: Tran
       };
     }
     case TransactionActionTypes.UPDATE_SENDER_BALANCES: {
-      const { senderAccountBalance, senderCompanionAccountBalance } = action.payload;
-      const { transferAmount, estimatedFee, transactionReadyToExecute, action: transactionType, senderAccount } = state;
-      const { evaluateTransactionStatusError, notEnoughFundsToTransfer, notEnoughToPayFee } = enoughFundsEvaluation({
-        transferAmount,
-        senderCompanionAccountBalance,
-        senderAccountBalance,
-        estimatedFee
-      });
+      const { action: transactionType, senderAccount } = state;
 
       const shouldEvaluatePayloadEstimatedFee = shouldCalculatePayloadFee(state, {
         senderAccount,
@@ -280,7 +273,6 @@ export default function transactionReducer(state: TransactionState, action: Tran
         transactionReadyToExecute: false
       };
     }
-
     case TransactionActionTypes.UPDATE_TRANSACTIONS_STATUS: {
       const { evaluateTransactionStatusError, transactions, evaluatingTransactions } = action.payload;
       return {
@@ -290,6 +282,14 @@ export default function transactionReducer(state: TransactionState, action: Tran
         evaluateTransactionStatusError
       };
     }
+    case TransactionActionTypes.SET_TRANSFER_TYPE: {
+      const { transferType } = action.payload;
+      return {
+        ...state,
+        action: transferType
+      };
+    }
+
     default:
       throw new Error(`Unknown type: ${action.type}`);
   }

--- a/src/screens/Main.tsx
+++ b/src/screens/Main.tsx
@@ -29,9 +29,10 @@ import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
 import Transactions from '../components/Transactions';
 import { useGUIContext } from '../contexts/GUIContextProvider';
 import { TransactionTypes } from '../types/transactionTypes';
-
+import { TransactionActionCreators } from '../actions/transactionActions';
 import BridgedLocalWrapper from '../components/BridgedLocalWrapper';
 import { useCallback } from 'react';
+import { useUpdateTransactionContext } from '../contexts/TransactionContext';
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -50,12 +51,18 @@ const ActionComponents = {
 function Main() {
   const classes = useStyles();
   const { actions, action, setAction, isBridged, setBridged } = useGUIContext();
+  const { dispatchTransaction } = useUpdateTransactionContext();
 
   const handleOnSwitch = useCallback(
-    (event: React.MouseEvent<HTMLElement>, newAlignment: string | null) => {
-      setBridged(Boolean(newAlignment));
+    (event: React.MouseEvent<HTMLElement>, isBridged: boolean) => {
+      setBridged(isBridged);
+      dispatchTransaction(
+        TransactionActionCreators.setTransferType(
+          isBridged ? TransactionTypes.TRANSFER : TransactionTypes.INTERNAL_TRANSFER
+        )
+      );
     },
-    [setBridged]
+    [dispatchTransaction, setBridged]
   );
 
   // TODO #242: ToggleButtonGroup needs to contain the colors designed by custom css.

--- a/src/types/transactionTypes.ts
+++ b/src/types/transactionTypes.ts
@@ -40,7 +40,8 @@ export enum SwitchTabEnum {
   PAYLOAD = 'PAYLOAD',
   DECODED = 'DECODED'
 }
-export interface TransactionPayload {
+
+export interface BridgedTransactionPayload {
   call: Uint8Array;
   origin: {
     SourceAccount: Uint8Array;
@@ -49,20 +50,28 @@ export interface TransactionPayload {
   weight: number;
 }
 
+export interface InternalTransferPayload {
+  sourceAccount: string | null;
+  transferAmount: number;
+  receiverAddress: string | null;
+  weight: number;
+}
+
+export type TransactionPayload = BridgedTransactionPayload | InternalTransferPayload;
+
 export interface TransactionDisplayPayload {
   call: Object;
   origin: Object;
   spec_version: string;
-  weight: string;
+  weight: number;
 }
 
-export interface LocalTransactionDisplayPayload {
-  sourceAccount: string;
-  transferAmount: number;
-  receiverAddress: string;
-}
+export type PayloadEstimatedFee = {
+  payload: TransactionPayload | null;
+  estimatedFee: string | null;
+};
 
-export type DisplayPayload = TransactionDisplayPayload | LocalTransactionDisplayPayload;
+export type DisplayPayload = TransactionDisplayPayload | InternalTransferPayload;
 
 export interface TransactionStatusType extends UpdatedTransactionStatusType {
   input: string;
@@ -138,8 +147,3 @@ export interface ReceiverPayload {
   targetChainDetails: ChainState;
   isBridged: boolean;
 }
-
-export type PayloadEstimatedFee = {
-  payload: TransactionPayload | null;
-  estimatedFee: string | null;
-};

--- a/src/util/transactions/index.ts
+++ b/src/util/transactions/index.ts
@@ -128,11 +128,10 @@ export async function getTransactionCallWeight({
       case TransactionTypes.INTERNAL_TRANSFER:
         if (receiverAddress) {
           call = (await sourceApi.tx.balances.transfer(receiverAddress, transferAmount || 0)).toU8a();
-          // TODO [#121] Figure out what the extra bytes are about
           call = call.slice(2);
           logger.info(`balances::transfer: ${u8aToHex(call)}`);
           weight = (
-            await targetApi.tx.balances.transfer(receiverAddress, transferAmount || 0).paymentInfo(account)
+            await sourceApi.tx.balances.transfer(receiverAddress, transferAmount || 0).paymentInfo(account)
           ).weight.toNumber();
         }
         break;


### PR DESCRIPTION
Closes #262 . 
Closes #267.

As described in the GH issue 262, this PR is actually implementing the following two behaviors:

1) validate that native sender balance is enough to pay the fees.
2) validate that sender companion balance is enough to deduct the amount.

Another enhancement introduced on this PR is that the enough funds calculation is now happening on the reducer logic 100% and there is a hook in the data model that triggers the update in case balance gets updated.

Also this PR solves the bug described in the #267 and now the fee is correctly deducted from the balance sender ( shows the same fee as polkadotjs )