### PR TITLE
Fixing some styles around Sender component.

### DIFF
--- a/src/components/Sender.tsx
+++ b/src/components/Sender.tsx
@@ -18,8 +18,16 @@ import React, { useState } from 'react';
 import SenderDropdown from './SenderDropdown';
 import SenderAccount from './SenderAccount';
 import SenderCompanionAccount from './SenderCompanionAccount';
+import { makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles((theme) => ({
+  sender: {
+    minHeight: theme.spacing(13)
+  }
+}));
 
 export default function Sender() {
+  const classes = useStyles();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
@@ -32,9 +40,11 @@ export default function Sender() {
 
   return (
     <>
-      <SenderAccount handleClick={handleClick} anchorEl={anchorEl} />
-      <SenderDropdown anchorEl={anchorEl} removeAnchor={removeAnchor} />
-      <SenderCompanionAccount />
+      <div className={classes.sender}>
+        <SenderAccount handleClick={handleClick} anchorEl={anchorEl} />
+        <SenderDropdown anchorEl={anchorEl} removeAnchor={removeAnchor} />
+        <SenderCompanionAccount />
+      </div>
     </>
   );
 }

--- a/src/components/SenderAccount.tsx
+++ b/src/components/SenderAccount.tsx
@@ -15,6 +15,7 @@
 // along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from 'react';
+import cx from 'classnames';
 import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 import ArrowDropUp from '@material-ui/icons/ArrowDropUp';
 import AccountDisplay from './AccountDisplay';
@@ -26,6 +27,7 @@ import { Box } from '@material-ui/core';
 import { useSourceTarget } from '../contexts/SourceTargetContextProvider';
 
 import { encodeAddress } from '@polkadot/util-crypto';
+import { useGUIContext } from '../contexts/GUIContextProvider';
 
 interface Props {
   handleClick: (event: React.MouseEvent<HTMLElement>) => void;
@@ -40,12 +42,11 @@ const useStyles = makeStyles((theme) => ({
     paddingTop: theme.spacing(0.5),
     paddingRight: theme.spacing(0),
     border: `1px solid ${theme.palette.divider}`,
-    borderRadius: theme.spacing(1.5),
+    borderRadius: theme.spacing(1.5)
+  },
+  withoutBottomBorderRadius: {
     borderBottomLeftRadius: 0,
     borderBottomRightRadius: 0
-  },
-  sender: {
-    minHeight: theme.spacing(10)
   },
   paper: {
     minWidth: theme.spacing(60),
@@ -65,6 +66,7 @@ const useStyles = makeStyles((theme) => ({
 export default function SenderAccount({ handleClick, anchorEl }: Props) {
   const classes = useStyles();
   const { account, senderAccountBalance } = useAccountContext();
+  const { isBridged } = useGUIContext();
   const {
     sourceChainDetails: {
       configs: { ss58Format }
@@ -75,7 +77,12 @@ export default function SenderAccount({ handleClick, anchorEl }: Props) {
   const id = open ? 'simple-popover' : undefined;
 
   return (
-    <Box onClick={handleClick} p={1} className={classes.accountMain} id="test-sender-component">
+    <Box
+      onClick={handleClick}
+      p={1}
+      className={cx(classes.accountMain, isBridged ? classes.withoutBottomBorderRadius : '')}
+      id="test-sender-component"
+    >
       <SelectLabel>Sender</SelectLabel>
       <Box display="flex">
         <div className={classes.account}>

--- a/src/components/SenderAccountsListByChain.tsx
+++ b/src/components/SenderAccountsListByChain.tsx
@@ -59,7 +59,7 @@ export default function SenderAccountsListByChain({ chain, showCompanion, showEm
 
   return (
     <>
-      <ChainHeader chain={chain} />
+      {Boolean(accounts.length) && <ChainHeader chain={chain} />}
       {accounts.map((option) => {
         const component = (
           <SenderDropdownItem

--- a/src/components/SenderAccountsSection.tsx
+++ b/src/components/SenderAccountsSection.tsx
@@ -16,7 +16,7 @@
 
 import React, { useMemo } from 'react';
 
-import { Divider } from '@material-ui/core';
+import { Divider, makeStyles } from '@material-ui/core';
 import SenderAccountsListByChain from './SenderAccountsListByChain';
 import { useAccountContext } from '../contexts/AccountContextProvider';
 interface Props {
@@ -26,13 +26,21 @@ interface Props {
   handleClose: () => void;
 }
 
+const useStyles = makeStyles((theme) => ({
+  paper: {
+    height: theme.spacing(39),
+    overflow: 'scroll'
+  }
+}));
+
 export default function SenderAccountsSection({ showEmpty, showCompanion, filter, handleClose }: Props) {
+  const classes = useStyles();
   const { displaySenderAccounts } = useAccountContext();
   const chains = useMemo(() => Object.keys(displaySenderAccounts), [displaySenderAccounts]);
 
   if (chains.length) {
     return (
-      <>
+      <div className={classes.paper}>
         <SenderAccountsListByChain
           chain={chains[0]}
           showCompanion={showCompanion}
@@ -48,7 +56,7 @@ export default function SenderAccountsSection({ showEmpty, showCompanion, filter
           handleClose={handleClose}
           filter={filter}
         />
-      </>
+      </div>
     );
   }
   return null;

--- a/src/components/SenderDropdown.tsx
+++ b/src/components/SenderDropdown.tsx
@@ -30,11 +30,10 @@ const useStyles = makeStyles((theme) => ({
   paper: {
     minWidth: theme.spacing(56),
     maxHeight: theme.spacing(50),
+    minHeight: theme.spacing(50),
     border: `1px solid ${theme.palette.primary.light}`,
     borderRadius: theme.spacing(1.5),
-    '&::-webkit-scrollbar': {
-      display: 'none'
-    }
+    overflow: 'hidden'
   }
 }));
 


### PR DESCRIPTION
Related with #270 

Items performed:

- have a fixed size - currently, after filtering it might be reduced.
- Network label is still displayed even if all accounts from that network are filtered out.
-The selector is now fixed on top, and only the account list scrollable (also would be good to display a tiny scrollbar)