### PR TITLE
Adding tx cancel use case to enable the submit button back

### DIFF
--- a/src/actions/transactionActions.ts
+++ b/src/actions/transactionActions.ts
@@ -46,6 +46,7 @@ enum TransactionActionTypes {
   SET_BATCH_PAYLOAD_ESTIMATED_FEE = 'SET_BATCH_PAYLOAD_ESTIMATED_FEE',
   UPDATE_SENDER_BALANCES = 'UPDATE_SENDER_BALANCES',
   SET_TRANSFER_TYPE = 'SET_TRANSFER_TYPE',
+  ENABLE_TX_BUTTON = 'ENABLE_TX_BUTTON',
   RESET = 'RESET'
 }
 
@@ -167,6 +168,11 @@ const setTransferType = (transferType: TransactionTypes) => ({
   type: TransactionActionTypes.SET_TRANSFER_TYPE
 });
 
+const enableTxButton = () => ({
+  payload: {},
+  type: TransactionActionTypes.ENABLE_TX_BUTTON
+});
+
 const TransactionActionCreators = {
   setSender,
   setAction,
@@ -184,6 +190,7 @@ const TransactionActionCreators = {
   setBatchedEvaluationPayloadEstimatedFee,
   updateSenderBalances,
   setTransferType,
+  enableTxButton,
   reset
 };
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,3 +32,4 @@ export const TIMER_DURATION = 30000;
 export const MESSAGE_DISPATCH_EVENT = 'MessageDispatched';
 export const MESSAGE_NONCE_TYPE = 'MessageNonce';
 export const OK = 'OK';
+export const TX_CANCELLED = 'Cancelled';

--- a/src/hooks/chain/useSendMessage.ts
+++ b/src/hooks/chain/useSendMessage.ts
@@ -31,6 +31,7 @@ import { getSubstrateDynamicNames } from '../../util/getSubstrateDynamicNames';
 import { createEmptySteps, getTransactionDisplayPayload } from '../../util/transactions/';
 import logger from '../../util/logger';
 import useApiCalls from '../api/useApiCalls';
+import { TX_CANCELLED } from '../../constants';
 
 interface Props {
   input: string;
@@ -147,8 +148,14 @@ function useSendMessage({ input, type }: Props) {
           }
         });
       } catch (e) {
-        dispatchMessage(MessageActionsCreators.triggerErrorMessage({ message: e.message }));
         logger.error(e.message);
+        if (e.message === TX_CANCELLED) {
+          dispatchTransaction(TransactionActionCreators.enableTxButton());
+          return dispatchMessage(
+            MessageActionsCreators.triggerErrorMessage({ message: 'Transaction was cancelled from the extension.' })
+          );
+        }
+        dispatchMessage(MessageActionsCreators.triggerErrorMessage({ message: e.message }));
       } finally {
         dispatchTransaction(TransactionActionCreators.setTransactionRunning(false));
       }

--- a/src/reducers/transactionReducer.ts
+++ b/src/reducers/transactionReducer.ts
@@ -242,7 +242,11 @@ export default function transactionReducer(state: TransactionState, action: Tran
     case TransactionActionTypes.SET_RECEIVER:
       return setReceiver(state, action.payload.receiverPayload);
     case TransactionActionTypes.SET_TRANSACTION_RUNNING:
-      return { ...state, transactionRunning: action.payload.transactionRunning, transactionReadyToExecute: false };
+      return {
+        ...state,
+        transactionRunning: action.payload.transactionRunning,
+        transactionReadyToExecute: action.payload.transactionRunning ? false : state.transactionReadyToExecute
+      };
     case TransactionActionTypes.SET_ACTION: {
       const { action: transactionType } = action.payload;
 
@@ -289,7 +293,12 @@ export default function transactionReducer(state: TransactionState, action: Tran
         action: transferType
       };
     }
-
+    case TransactionActionTypes.ENABLE_TX_BUTTON: {
+      return {
+        ...state,
+        transactionReadyToExecute: true
+      };
+    }
     default:
       throw new Error(`Unknown type: ${action.type}`);
   }


### PR DESCRIPTION
Related with #276 .

This issue solves one of the conflicts that when a TX is cancelled from the extension , the submit button was not enabled.
This PR changes that behavior.