### PR TITLE
Fixing width for Sender Component.

### DIFF
--- a/src/components/SenderAccountsListByChain.tsx
+++ b/src/components/SenderAccountsListByChain.tsx
@@ -67,6 +67,7 @@ export default function SenderAccountsListByChain({ chain, showCompanion, showEm
             address={option.account.address}
             balance={option.account.balance.formattedBalance}
             companionBalance={option.companionAccount.balance.formattedBalance}
+            companionAddress={option.companionAccount.address}
             showCompanion={showCompanion}
           />
         );

--- a/src/components/SenderDropdownItem.tsx
+++ b/src/components/SenderDropdownItem.tsx
@@ -27,6 +27,7 @@ interface Props {
   companionBalance: string;
   address: string;
   showCompanion: boolean;
+  companionAddress: string;
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -66,13 +67,26 @@ const useStyles = makeStyles((theme) => ({
   address: {
     marginLeft: theme.spacing(0.5)
   },
-  addressContainer: { maxWidth: theme.spacing(30) }
+  addressContainer: {
+    maxWidth: theme.spacing(30)
+  },
+  tooltip: {
+    maxWidth: 350
+  }
 }));
 
-const SenderDropdownItem = ({ name, address, balance, companionBalance, showCompanion }: Props) => {
+const SenderDropdownItem = ({ name, address, balance, companionBalance, showCompanion, companionAddress }: Props) => {
   const classes = useStyles();
   const [hoover, setHoover] = useState(false);
   const { isBridged } = useGUIContext();
+
+  const companionTitle = ` Companion: ${companionAddress}`;
+  let title = `Native: ${address}`;
+
+  if (isBridged) {
+    title = title.concat(companionTitle);
+  }
+
   return (
     <div
       className={cx(classes.main, hoover ? classes.hoover : '')}
@@ -83,7 +97,7 @@ const SenderDropdownItem = ({ name, address, balance, companionBalance, showComp
         setHoover(false);
       }}
     >
-      <Tooltip placement="top" title={address} aria-label="add">
+      <Tooltip placement="top" title={title} aria-label="add" classes={{ tooltip: classes.tooltip }} arrow>
         <Box display="flex" className={classes.box} id="test-transaction-header" alignItems="start">
           <AccountIdenticon address={address} />
           <div className={classes.addressContainer}>

--- a/src/components/SenderDropdownItem.tsx
+++ b/src/components/SenderDropdownItem.tsx
@@ -16,7 +16,7 @@
 
 import React, { useState } from 'react';
 import cx from 'classnames';
-import { Box, makeStyles, Typography } from '@material-ui/core';
+import { Box, makeStyles, Typography, Tooltip } from '@material-ui/core';
 import shorterItem from '../util/shortenItem';
 import AccountIdenticon from './AccountIdenticon';
 import { useGUIContext } from '../contexts/GUIContextProvider';
@@ -31,8 +31,10 @@ interface Props {
 
 const useStyles = makeStyles((theme) => ({
   topBalance: {
-    minWidth: theme.spacing(14)
+    minWidth: theme.spacing(14),
+    marginLeft: theme.spacing(5)
   },
+
   bottomBalance: {
     border: `1px solid ${theme.palette.divider}`,
     borderRadius: theme.spacing(0.5),
@@ -63,7 +65,8 @@ const useStyles = makeStyles((theme) => ({
   },
   address: {
     marginLeft: theme.spacing(0.5)
-  }
+  },
+  addressContainer: { maxWidth: theme.spacing(30) }
 }));
 
 const SenderDropdownItem = ({ name, address, balance, companionBalance, showCompanion }: Props) => {
@@ -80,31 +83,41 @@ const SenderDropdownItem = ({ name, address, balance, companionBalance, showComp
         setHoover(false);
       }}
     >
-      <Box display="flex" className={classes.box} id="test-transaction-header" alignItems="start">
-        <AccountIdenticon address={address} />
-        <Typography classes={{ root: classes.address }}>
-          {name} [{shorterItem(address)}]
-        </Typography>
-
-        <Box marginLeft="auto" display="flex" flexDirection="column" alignItems="flex-end" id="test-transaction-header">
-          <Box
-            className={cx(classes.topBalance, isBridged && showCompanion ? classes.border : '')}
-            display="flex"
-            justifyContent="flex-end"
-          >
-            <Typography component="p" className={classes.balanceBody}>
-              {balance}
+      <Tooltip placement="top" title={address} aria-label="add">
+        <Box display="flex" className={classes.box} id="test-transaction-header" alignItems="start">
+          <AccountIdenticon address={address} />
+          <div className={classes.addressContainer}>
+            <Typography noWrap classes={{ root: classes.address }}>
+              {name} [{shorterItem(address)}]
             </Typography>
-          </Box>
-          {showCompanion && isBridged && (
-            <Box className={classes.bottomBalance} display="flex" justifyContent="flex-end">
+          </div>
+
+          <Box
+            marginLeft="auto"
+            display="flex"
+            flexDirection="column"
+            alignItems="flex-end"
+            id="test-transaction-header"
+          >
+            <Box
+              className={cx(classes.topBalance, isBridged && showCompanion ? classes.border : '')}
+              display="flex"
+              justifyContent="flex-end"
+            >
               <Typography component="p" className={classes.balanceBody}>
-                {companionBalance}
+                {balance}
               </Typography>
             </Box>
-          )}
+            {showCompanion && isBridged && (
+              <Box className={classes.bottomBalance} display="flex" justifyContent="flex-end">
+                <Typography component="p" className={classes.balanceBody}>
+                  {companionBalance}
+                </Typography>
+              </Box>
+            )}
+          </Box>
         </Box>
-      </Box>
+      </Tooltip>
     </div>
   );
 };


### PR DESCRIPTION
Related to #276 #270 

This PR solves some design issues related with sender component size when account names are larger:

1) Balance has a margin left now.
2) The account name has an ellipsis that wraps the text and does not increase the size.
3) When the focus is on the address item, there is a tooltip that shows native/companion addresses:

screenshots below:

<img width="455" alt="Screen Shot 2021-09-17 at 10 53 37" src="https://user-images.githubusercontent.com/12089572/133794314-9f486e92-22e8-4435-b0ab-c77d83217ecd.png">

<img width="454" alt="Screen Shot 2021-09-17 at 10 53 48" src="https://user-images.githubusercontent.com/12089572/133794329-f7e40f24-62dc-42e2-b762-20499aec6354.png">

<img width="451" alt="Screen Shot 2021-09-17 at 10 53 59" src="https://user-images.githubusercontent.com/12089572/133794342-47651c51-d79b-4d7f-8c0b-084a78eb030a.png">
 