### PR TITLE
Removing jumping behavior on decoded tab.

### DIFF
--- a/src/components/TransactionPayload.tsx
+++ b/src/components/TransactionPayload.tsx
@@ -14,12 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Card, makeStyles, CircularProgress, Typography } from '@material-ui/core';
 import ReactJson from 'react-json-view';
 import TransactionHeader from './TransactionHeader';
+import { MessageActionsCreators } from '../actions/messageActions';
 import { useTransactionContext } from '../contexts/TransactionContext';
 import { DisplayPayload, SwitchTabEnum, TransactionStatusEnum } from '../types/transactionTypes';
+import { useUpdateMessageContext } from '../contexts/MessageContext';
 
 export interface TransactionDisplayProps {
   size?: 'sm';
@@ -74,6 +76,17 @@ const TransactionPayload = ({
 }: Props) => {
   const classes = useStyles();
   const { payloadEstimatedFeeLoading } = useTransactionContext();
+  const { dispatchMessage } = useUpdateMessageContext();
+
+  const onCopy = useCallback(() => {
+    navigator.clipboard.writeText(JSON.stringify(transactionDisplayPayload));
+    dispatchMessage(
+      MessageActionsCreators.triggerSuccessMessage({
+        message: 'Payload copied'
+      })
+    );
+  }, [dispatchMessage, transactionDisplayPayload]);
+
   if (tab === SwitchTabEnum.RECEIPT) {
     return null;
   }
@@ -92,9 +105,16 @@ const TransactionPayload = ({
         <Typography variant="subtitle2">{payloadHex}</Typography>
       )}
       {!payloadEstimatedFeeLoading && tab === SwitchTabEnum.DECODED && transactionDisplayPayload && (
-        <Typography variant="subtitle2">
-          <ReactJson src={transactionDisplayPayload} enableClipboard={false} name={false} />
-        </Typography>
+        <div onClick={onCopy}>
+          <Typography variant="subtitle2">
+            <ReactJson
+              src={transactionDisplayPayload}
+              enableClipboard={false}
+              name={false}
+              style={{ cursor: 'copy' }}
+            />
+          </Typography>
+        </div>
       )}
     </Card>
   );

--- a/src/components/TransactionPayload.tsx
+++ b/src/components/TransactionPayload.tsx
@@ -93,7 +93,7 @@ const TransactionPayload = ({
       )}
       {!payloadEstimatedFeeLoading && tab === SwitchTabEnum.DECODED && transactionDisplayPayload && (
         <Typography variant="subtitle2">
-          <ReactJson src={transactionDisplayPayload} enableClipboard name={false} />
+          <ReactJson src={transactionDisplayPayload} enableClipboard={false} name={false} />
         </Typography>
       )}
     </Card>


### PR DESCRIPTION
Related #276 

> "Decoded" tab - copy icon jumps around (content is moving up/down - my suggestion would be to disable this completely and change the cursor to "arrow-plus").

This PR changes the clipboard on the payload tab. As this component relies completely on `ReactJson` library i'm afraid that manipulating the icon and the jumping behavior is not so direct.

I managed to disable the copy clipboard functionality so the jumping issue is gone. 

@tomusdrw i'm not sure if what you mean by "change the cursor to "arrow-plus" , but i have added the following cursor in case this is what you wanted (if not i can simply remove it)

<img width="432" alt="Screen Shot 2021-09-17 at 17 19 51" src="https://user-images.githubusercontent.com/12089572/133849129-6ff078a1-d62b-4fdd-9c99-1b065d1a97d4.png">


