### PR TITLE
Adding filter by chain in the search bar.

### DIFF
--- a/src/components/SenderAccountsListByChain.tsx
+++ b/src/components/SenderAccountsListByChain.tsx
@@ -17,6 +17,7 @@
 import React, { useMemo } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { useAccountContext } from '../contexts/AccountContextProvider';
+import { getFilteredAccounts } from '../util/sender/filters';
 import ChainHeader from './ChainHeader';
 import SenderDropdownItem from './SenderDropdownItem';
 import useAccounts from '../hooks/accounts/useAccounts';
@@ -48,64 +49,12 @@ export default function SenderAccountsListByChain({
   const { setCurrentAccount } = useAccounts();
   const classes = useStyles();
 
-  const accounts = useMemo(() => {
-    const items = displaySenderAccounts[chain];
-    const upperChain = chain.toLocaleUpperCase();
-
-    const getItemsFiltered = () => {
-      if (filters.length) {
-        const match = (input: string, caseSensitive = false) => {
-          let field = input;
-          let show = false;
-          if (!caseSensitive) {
-            field = input.toUpperCase();
-            filters.forEach((f) => {
-              if (field.includes(f.toUpperCase())) {
-                show = true;
-              }
-            });
-            return show;
-          }
-
-          filters.forEach((f) => {
-            console.log('----');
-            console.log('f', f);
-            console.log('field', field);
-            console.log('field.includes(f)', field.includes(f));
-
-            if (field.includes(f)) {
-              show = true;
-            }
-          });
-          return show;
-        };
-
-        return items.filter(({ account, companionAccount }) => {
-          const matchAddress = match(account.address, true);
-          const matchCompanionAddress = match(companionAccount.address, true);
-          const matchName = match(account.name);
-          return matchAddress || matchCompanionAddress || matchName;
-        });
-      }
-      return [];
-    };
-
-    if (chainMatch && !upperChain.includes(chainMatch)) {
-      return [];
-    }
-
-    const filteredItems = getItemsFiltered();
-    console.log('filteredItems', filteredItems);
-    if (filteredItems.length) {
-      return filteredItems;
-    }
-
-    if (!chainMatch) {
-      return items;
-    }
-
-    return [];
-  }, [chain, displaySenderAccounts, filters, chainMatch]);
+  const accounts = useMemo(() => getFilteredAccounts({ displaySenderAccounts, chain, filters, chainMatch }), [
+    chain,
+    displaySenderAccounts,
+    filters,
+    chainMatch
+  ]);
 
   return (
     <>

--- a/src/components/SenderAccountsSection.tsx
+++ b/src/components/SenderAccountsSection.tsx
@@ -19,11 +19,12 @@ import React, { useMemo } from 'react';
 import { Divider, makeStyles } from '@material-ui/core';
 import SenderAccountsListByChain from './SenderAccountsListByChain';
 import { useAccountContext } from '../contexts/AccountContextProvider';
+import { getChainMatches } from '../util/sender/filters';
 
 interface Props {
   showCompanion: boolean;
   showEmpty: boolean;
-  filter: string | null;
+  filterInput: string | null;
   handleClose: () => void;
 }
 
@@ -34,41 +35,14 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
-export default function SenderAccountsSection({ showEmpty, showCompanion, filter, handleClose }: Props) {
+export default function SenderAccountsSection({ showEmpty, showCompanion, filterInput, handleClose }: Props) {
   const classes = useStyles();
   const { displaySenderAccounts } = useAccountContext();
 
-  const [chains, filters, chainMatch] = useMemo((): [string[], string[], string | undefined] => {
-    const chains = Object.keys(displaySenderAccounts);
-    const splitFilter = filter ? filter.split(' ').filter((n) => n !== '') : [];
-
-    let chainMatch: string | undefined;
-    let fullChainNameMatched = '';
-    if (splitFilter.length) {
-      splitFilter.forEach((f) =>
-        chains.forEach((c) => {
-          const upperC = c.toUpperCase();
-          if (upperC.includes(f.toUpperCase())) {
-            chainMatch = f.toUpperCase();
-            if (upperC === f.toUpperCase()) {
-              fullChainNameMatched = upperC;
-            }
-          }
-        })
-      );
-    }
-
-    if (chainMatch) {
-      if (fullChainNameMatched) {
-        const filters = splitFilter.filter((sf) => sf.toUpperCase() !== fullChainNameMatched);
-        return [chains, filters, fullChainNameMatched];
-      }
-      const filters = splitFilter.filter((sf) => sf.toUpperCase() !== chainMatch);
-      return [chains, filters, chainMatch];
-    }
-
-    return [chains, splitFilter, undefined];
-  }, [displaySenderAccounts, filter]);
+  const [chains, filters, chainMatch] = useMemo(() => getChainMatches(displaySenderAccounts, filterInput), [
+    displaySenderAccounts,
+    filterInput
+  ]);
 
   if (chains.length) {
     return (

--- a/src/components/SenderDropdown.tsx
+++ b/src/components/SenderDropdown.tsx
@@ -41,14 +41,14 @@ export default function SenderDropdown({ anchorEl, removeAnchor }: Props) {
   const classes = useStyles();
   const [showEmpty, setShowEmpty] = useState(true);
   const [showCompanion, setShowCompanion] = useState(true);
-  const [filter, setFilter] = useState<string | null>(null);
+  const [filterInput, setFilterInput] = useState<string | null>(null);
   const { initialLoadingAccounts } = useAccountContext();
   const open = Boolean(anchorEl);
   const id = open ? 'test-sender-component' : undefined;
 
   const handleClose = useCallback(() => {
     removeAnchor();
-    setFilter(null);
+    setFilterInput(null);
   }, [removeAnchor]);
 
   return (
@@ -74,7 +74,7 @@ export default function SenderDropdown({ anchorEl, removeAnchor }: Props) {
       ) : (
         <>
           <SenderFilters
-            setFilter={setFilter}
+            setFilterInput={setFilterInput}
             setShowEmpty={setShowEmpty}
             setShowCompanion={setShowCompanion}
             showEmpty={showEmpty}
@@ -83,7 +83,7 @@ export default function SenderDropdown({ anchorEl, removeAnchor }: Props) {
           <SenderAccountsSection
             showEmpty={showEmpty}
             showCompanion={showCompanion}
-            filter={filter}
+            filterInput={filterInput}
             handleClose={handleClose}
           />
         </>

--- a/src/components/SenderFilters.tsx
+++ b/src/components/SenderFilters.tsx
@@ -22,7 +22,7 @@ import SenderActionSwitch from './SenderActionSwitch';
 import { useGUIContext } from '../contexts/GUIContextProvider';
 
 interface Props {
-  setFilter: (value: React.SetStateAction<string | null>) => void;
+  setFilterInput: (value: React.SetStateAction<string | null>) => void;
   setShowCompanion: (value: React.SetStateAction<boolean>) => void;
   setShowEmpty: (value: React.SetStateAction<boolean>) => void;
   showCompanion: boolean;
@@ -35,15 +35,21 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
-export default function SenderFilters({ setFilter, setShowEmpty, setShowCompanion, showEmpty, showCompanion }: Props) {
+export default function SenderFilters({
+  setFilterInput,
+  setShowEmpty,
+  setShowCompanion,
+  showEmpty,
+  showCompanion
+}: Props) {
   const classes = useStyles();
   const { isBridged } = useGUIContext();
 
   const handleChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      setFilter(event.target.value);
+      setFilterInput(event.target.value);
     },
-    [setFilter]
+    [setFilterInput]
   );
 
   return (

--- a/src/util/sender/filters/getChainMatches.ts
+++ b/src/util/sender/filters/getChainMatches.ts
@@ -1,0 +1,52 @@
+// Copyright 2021 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges UI.
+//
+// Parity Bridges UI is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Parity Bridges UI is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
+
+import { DisplayAccounts } from '../../../types/accountTypes';
+
+export default function getChainMatches(
+  displaySenderAccounts: DisplayAccounts,
+  filterInput: string | null
+): [string[], string[], string | undefined] {
+  const chains = Object.keys(displaySenderAccounts);
+  const splitFilter = filterInput ? filterInput.split(' ').filter((n) => n !== '') : [];
+
+  let chainMatch: string | undefined;
+  let fullChainNameMatched = '';
+  if (splitFilter.length) {
+    splitFilter.forEach((f) =>
+      chains.forEach((c) => {
+        const upperC = c.toUpperCase();
+        if (upperC.includes(f.toUpperCase())) {
+          chainMatch = f.toUpperCase();
+          if (upperC === f.toUpperCase()) {
+            fullChainNameMatched = upperC;
+          }
+        }
+      })
+    );
+  }
+
+  if (chainMatch) {
+    if (fullChainNameMatched) {
+      const filters = splitFilter.filter((sf) => sf.toUpperCase() !== fullChainNameMatched);
+      return [chains, filters, fullChainNameMatched];
+    }
+    const filters = splitFilter.filter((sf) => sf.toUpperCase() !== chainMatch);
+    return [chains, filters, chainMatch];
+  }
+
+  return [chains, splitFilter, undefined];
+}

--- a/src/util/sender/filters/getFileteredAccounts.ts
+++ b/src/util/sender/filters/getFileteredAccounts.ts
@@ -1,0 +1,82 @@
+// Copyright 2021 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges UI.
+//
+// Parity Bridges UI is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Parity Bridges UI is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
+
+import { DisplayAccounts } from '../../../types/accountTypes';
+
+interface Parameters {
+  displaySenderAccounts: DisplayAccounts;
+  chain: string;
+  filters: string[];
+  chainMatch: string | undefined;
+}
+
+export default function getFilteredAccounts({ displaySenderAccounts, chain, filters, chainMatch }: Parameters) {
+  const items = displaySenderAccounts[chain];
+  const upperChain = chain.toLocaleUpperCase();
+
+  const getItemsFiltered = () => {
+    if (filters.length) {
+      const match = (input: string, caseSensitive = true) => {
+        let show = false;
+
+        const field = caseSensitive ? input : input.toUpperCase();
+        filters.forEach((f) => {
+          if (field.includes(caseSensitive ? f : f.toUpperCase())) {
+            show = true;
+          }
+        });
+        return show;
+      };
+
+      return items.filter(({ account, companionAccount }) => {
+        const matchAddress = match(account.address);
+        const matchCompanionAddress = match(companionAccount.address);
+        const matchName = match(account.name, false);
+
+        if (matchName && filters.length === 1) {
+          return true;
+        }
+
+        if (matchName && !matchAddress && !matchCompanionAddress && filters.length > 1) {
+          return false;
+        }
+
+        return matchAddress || matchCompanionAddress || matchName;
+      });
+    }
+    return [];
+  };
+
+  if (!chainMatch && !filters.length) {
+    return items;
+  }
+
+  if (chainMatch && !upperChain.includes(chainMatch)) {
+    return [];
+  }
+
+  const filteredItems = getItemsFiltered();
+
+  if (chainMatch && upperChain.includes(chainMatch) && !filters.length) {
+    return items;
+  }
+
+  if (filteredItems.length) {
+    return filteredItems;
+  }
+
+  return [];
+}

--- a/src/util/sender/filters/index.ts
+++ b/src/util/sender/filters/index.ts
@@ -1,0 +1,20 @@
+// Copyright 2021 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges UI.
+//
+// Parity Bridges UI is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Parity Bridges UI is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
+
+import getChainMatches from './getChainMatches';
+import getFilteredAccounts from './getFileteredAccounts';
+
+export { getChainMatches, getFilteredAccounts };

--- a/src/util/sender/index.ts
+++ b/src/util/sender/index.ts
@@ -1,0 +1,19 @@
+// Copyright 2021 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges UI.
+//
+// Parity Bridges UI is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Parity Bridges UI is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
+
+import * as filters from './filters';
+
+export { filters };


### PR DESCRIPTION
Related to #277. It can be closed once the the behavior applied is approved by @tomusdrw 

In the issue description there was kind of suggestion to support something like "<Network> <name>" and even if this might work i think that can be hard for the user to understand the sequence without a tooltip or something like that. So basically i applied the filter in a way where the order does not matter, meaning that you can filter by address ( case sensitive filter ), name and network in any order.