### PR TITLE
Fix bug with dispatch fee selector for local transfers.

### DIFF
--- a/src/components/FeePaySelector.tsx
+++ b/src/components/FeePaySelector.tsx
@@ -21,6 +21,7 @@ import { PayFee } from '../types/transactionTypes';
 import { useSourceTarget } from '../contexts/SourceTargetContextProvider';
 import { useTransactionContext, useUpdateTransactionContext } from '../contexts/TransactionContext';
 import { TransactionActionCreators } from '../actions/transactionActions';
+import { useGUIContext } from '../contexts/GUIContextProvider';
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -38,6 +39,7 @@ export default function FeePaySelector() {
   const sourceTargetDetails = useSourceTarget();
   const { dispatchTransaction } = useUpdateTransactionContext();
   const { payFee } = useTransactionContext();
+  const { isBridged } = useGUIContext();
 
   const {
     sourceChainDetails: { chain: sourceChain },
@@ -52,6 +54,10 @@ export default function FeePaySelector() {
   );
 
   const chain = payFee === PayFee.AtSourceChain ? sourceChain : targetChain;
+
+  if (!isBridged) {
+    return null;
+  }
 
   return (
     <div className={classes.container}>

--- a/src/components/FeeValue.tsx
+++ b/src/components/FeeValue.tsx
@@ -15,6 +15,7 @@
 // along with Parity Bridges UI.  If not, see <http://www.gnu.org/licenses/>.
 
 import React from 'react';
+import cx from 'classnames';
 import { Typography, Tooltip } from '@material-ui/core';
 import { fade, makeStyles } from '@material-ui/core/styles';
 import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
@@ -45,9 +46,8 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 interface Props {
-  chainTokens: string;
   amount: string;
-  tooltip?: string;
+  tooltip?: string | null;
   showPlus?: boolean;
 }
 
@@ -59,20 +59,17 @@ interface TextStyle {
 const CustomTypography = ({ text, background = false }: TextStyle) => {
   const classes = useStyles();
   return (
-    <div className={classes.textContainer}>
-      <Typography variant="body1" className={background ? classes.value : ''}>
-        {text}
-      </Typography>
-    </div>
+    <Typography variant="body1" className={cx(classes.textContainer, background ? classes.value : '')}>
+      {text}
+    </Typography>
   );
 };
 
-export default function FeeValue({ tooltip = '', chainTokens, amount, showPlus = false }: Props) {
+export default function FeeValue({ tooltip = '', amount, showPlus = false }: Props) {
   const classes = useStyles();
   return (
     <div className={classes.container}>
       <CustomTypography text={amount} background />
-      <CustomTypography text={chainTokens} />
 
       {tooltip && (
         <Tooltip title={tooltip} arrow placement="top">

--- a/src/contexts/TransactionContext.tsx
+++ b/src/contexts/TransactionContext.tsx
@@ -20,7 +20,7 @@ import transactionReducer from '../reducers/transactionReducer';
 import { TransactionActionCreators } from '../actions/transactionActions';
 import useEstimatedFeePayload from '../hooks/transactions/useEstimatedFeePayload';
 import useResetTransactionState from '../hooks/transactions/useResetTransactionState';
-import { TransactionState, TransactionsActionType } from '../types/transactionTypes';
+import { TransactionState, TransactionsActionType, PayFee } from '../types/transactionTypes';
 import { useAccountContext } from './AccountContextProvider';
 import { useGUIContext } from './GUIContextProvider';
 import { initTransactionState } from '../reducers/initReducersStates/initTransactionState';
@@ -53,7 +53,7 @@ export function useUpdateTransactionContext() {
 export function TransactionContextProvider(props: TransactionContextProviderProps): React.ReactElement {
   const { children = null } = props;
   const { account, senderAccountBalance, senderCompanionAccountBalance } = useAccountContext();
-  const { action } = useGUIContext();
+  const { action, isBridged } = useGUIContext();
   const {
     sourceChainDetails: {
       configs: { ss58Format }
@@ -73,6 +73,10 @@ export function TransactionContextProvider(props: TransactionContextProviderProp
   useEffect((): void => {
     action && dispatchTransaction(TransactionActionCreators.setAction(action));
   }, [action]);
+
+  useEffect((): void => {
+    !isBridged && dispatchTransaction(TransactionActionCreators.changeDispatchFeePayChain(PayFee.AtSourceChain));
+  }, [isBridged]);
 
   return (
     <TransactionContext.Provider value={transactionsState}>

--- a/src/hooks/transactions/useEstimatedFeePayload.ts
+++ b/src/hooks/transactions/useEstimatedFeePayload.ts
@@ -102,7 +102,7 @@ export const useEstimatedFeePayload = (
           receiverAddress: currentTransactionState.receiverAddress,
           weight
         };
-        return { estimatedFee, payload };
+        return { estimatedSourceFee: estimatedFee, payload };
       }
       const { call, weight } = await getTransactionCallWeight({
         action,

--- a/src/hooks/transactions/useEstimatedFeePayload.ts
+++ b/src/hooks/transactions/useEstimatedFeePayload.ts
@@ -37,7 +37,13 @@ import { getFeeAndWeightForInternals, getTransactionCallWeight } from '../../uti
 import { useGUIContext } from '../../contexts/GUIContextProvider';
 import usePrevious from '../react/usePrevious';
 
-const emptyData = { payload: null, estimatedFee: null } as PayloadEstimatedFee;
+const emptyData = {
+  payload: null,
+  estimatedSourceFee: null,
+  estimatedFeeMessageDelivery: null,
+  estimatedFeeBridgeCall: null,
+  estimatedTargetFee: null
+} as PayloadEstimatedFee;
 
 export const useEstimatedFeePayload = (
   transactionState: TransactionState,

--- a/src/reducers/tests/transactionReducer.test.ts
+++ b/src/reducers/tests/transactionReducer.test.ts
@@ -171,7 +171,10 @@ describe('transactionReducer', () => {
   describe('SET_PAYLOAD_ESTIMATED_FEE', () => {
     type PayloadEstimatedFee = {
       payload: TransactionPayload | null;
-      estimatedFee: string | null;
+      estimatedSourceFee: string | null;
+      estimatedFeeMessageDelivery: string | null;
+      estimatedFeeBridgeCall: string | null;
+      estimatedTargetFee: string | null;
     };
 
     let payloadEstimatedFeeError: string | null;
@@ -180,7 +183,13 @@ describe('transactionReducer', () => {
 
     beforeEach(() => {
       payloadEstimatedFeeError = null;
-      payloadEstimatedFee = { estimatedFee: null, payload: null };
+      payloadEstimatedFee = {
+        estimatedSourceFee: null,
+        estimatedFeeMessageDelivery: null,
+        estimatedFeeBridgeCall: null,
+        estimatedTargetFee: null,
+        payload: null
+      };
       payloadEstimatedFeeLoading = false;
       (getTransactionDisplayPayload as jest.Mock).mockReturnValue({
         payloadHex: null,

--- a/src/types/transactionTypes.ts
+++ b/src/types/transactionTypes.ts
@@ -76,7 +76,10 @@ export interface TransactionDisplayPayload {
 
 export type PayloadEstimatedFee = {
   payload: TransactionPayload | null;
-  estimatedFee: string | null;
+  estimatedSourceFee: string | null;
+  estimatedFeeMessageDelivery: string | null;
+  estimatedFeeBridgeCall: string | null;
+  estimatedTargetFee: string | null;
 };
 
 export type DisplayPayload = TransactionDisplayPayload | InternalTransferPayload;


### PR DESCRIPTION
Related #266 .

There was a bug introduced in the PR #300 where the fee for the local transaction were not being shown.

This PR solves that issue and shows the fee correctly on both cases now.
Also old references to `estimatedFee` variable were cleaned.