### PR TITLE
Pin/bump GHA versions and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -18,12 +18,12 @@ jobs:
         node-version: [14.x,15.x,16.x]
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.4.1
+      uses: styfle/cancel-workflow-action@bb6001c4ea612bf59c3abfc4756fbceee4f870c7 # 0.10.0
       with:
         access_token: ${{ github.token }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set-up node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - run: yarn
@@ -39,13 +39,13 @@ jobs:
     steps:
 
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.4.1
+      uses: styfle/cancel-workflow-action@bb6001c4ea612bf59c3abfc4756fbceee4f870c7 # 0.10.0
       with:
         access_token: ${{ github.token }}
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set-up node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - run: yarn
@@ -60,12 +60,12 @@ jobs:
         node-version: [16.x]
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.4.1
+      uses: styfle/cancel-workflow-action@bb6001c4ea612bf59c3abfc4756fbceee4f870c7 # 0.10.0
       with:
         access_token: ${{ github.token }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set-up node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - run: yarn

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -75,7 +75,7 @@ jobs:
         PUBLIC_URL: 'https://paritytech.github.io/parity-bridges-ui'
     - name: Deploy to GitHub Pages
       if: success() && github.ref == 'refs/heads/master'
-      uses: crazy-max/ghaction-github-pages@v2
+      uses: crazy-max/ghaction-github-pages@eb08c35b9fab86751edfff4e55cd5cde35ff0e52 # v3.0.0
       with:
         target_branch: gh-pages
         build_dir: build

--- a/.github/workflows/publish-release-container.yml
+++ b/.github/workflows/publish-release-container.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on:                      ubuntu-latest
     steps:
 
-    - uses:                       actions/checkout@v2
+    - uses:                       actions/checkout@v3
 
     - name:                       Build Image
-      uses:                       redhat-actions/buildah-build@v2.2
+      uses:                       redhat-actions/buildah-build@v2
       with:
         image:                    parity-bridges-ui
         tags:                     ${{ github.event.release.tag_name }} latest
@@ -27,7 +27,7 @@ jobs:
 
     - name:                       Push image to docker.io
       id:                         push-to-dockerhub
-      uses:                       redhat-actions/push-to-registry@v2.1.1
+      uses:                       redhat-actions/push-to-registry@v2
       with:
         registry:                 docker.io/paritytech
         image:                    parity-bridges-ui


### PR DESCRIPTION
In order to improve our security posture with GitHub Actions usage. I've made a version pinning ether to commit hash or to specific version.
Additionally added `dependabot` to track GHA version changes.
Related issues and policy:
https://github.com/paritytech/ci_cd/issues/114
https://github.com/paritytech/ci_cd/issues/464
https://github.com/paritytech/ci_cd/wiki/Policies-and-regulations:-GitHub-Actions-usage-policies
